### PR TITLE
DX-2447: Handle tool-call and todo events in CLI

### DIFF
--- a/packages/cli/src/__tests__/repl/commands/run.test.ts
+++ b/packages/cli/src/__tests__/repl/commands/run.test.ts
@@ -29,4 +29,169 @@ describe("handleRun", () => {
     const events = await collectEvents(handleRun({} as any, ""));
     expect(events).toContainEqual({ type: "log", message: "Usage: run <prompt>" });
   });
+
+  it("yields tool event for Bash with description and command detail", async () => {
+    async function* fakeStream(): AsyncGenerator<Chunk> {
+      yield {
+        type: "tool-call",
+        toolName: "Bash",
+        input: { command: "npm install", description: "Install dependencies" },
+      };
+    }
+
+    const mockBox = { agent: { stream: vi.fn().mockReturnValue(fakeStream()) } };
+    const events = await collectEvents(handleRun(mockBox as any, "setup project"));
+
+    expect(events).toContainEqual({
+      type: "tool",
+      tool: { name: "Bash", summary: "Install dependencies", detail: "npm install" },
+    });
+  });
+
+  it("yields tool event for Read tool-call with basename", async () => {
+    async function* fakeStream(): AsyncGenerator<Chunk> {
+      yield {
+        type: "tool-call",
+        toolName: "Read",
+        input: { file_path: "/Users/dev/project/config.ts" },
+      };
+    }
+
+    const mockBox = { agent: { stream: vi.fn().mockReturnValue(fakeStream()) } };
+    const events = await collectEvents(handleRun(mockBox as any, "read config"));
+
+    expect(events).toContainEqual({
+      type: "tool",
+      tool: { name: "Read", summary: "config.ts", detail: undefined },
+    });
+  });
+
+  it("yields todo event for TodoWrite tool-call", async () => {
+    async function* fakeStream(): AsyncGenerator<Chunk> {
+      yield {
+        type: "tool-call",
+        toolName: "TodoWrite",
+        input: {
+          todos: [
+            { content: "Fix the bug", status: "in_progress" },
+            { content: "Write tests", status: "pending" },
+            { content: "Deploy", status: "completed" },
+          ],
+        },
+      };
+    }
+
+    const mockBox = { agent: { stream: vi.fn().mockReturnValue(fakeStream()) } };
+    const events = await collectEvents(handleRun(mockBox as any, "plan work"));
+
+    const todoEvent = events.find((e) => e.type === "todo");
+    expect(todoEvent).toBeDefined();
+    expect(todoEvent).toEqual({
+      type: "todo",
+      todos: [
+        { content: "Fix the bug", status: "in_progress", activeForm: undefined },
+        { content: "Write tests", status: "pending", activeForm: undefined },
+        { content: "Deploy", status: "completed", activeForm: undefined },
+      ],
+    });
+  });
+
+  it("yields tool event for unknown tool name", async () => {
+    async function* fakeStream(): AsyncGenerator<Chunk> {
+      yield {
+        type: "tool-call",
+        toolName: "CustomTool",
+        input: { foo: "bar" },
+      };
+    }
+
+    const mockBox = { agent: { stream: vi.fn().mockReturnValue(fakeStream()) } };
+    const events = await collectEvents(handleRun(mockBox as any, "do something"));
+
+    expect(events).toContainEqual({
+      type: "tool",
+      tool: { name: "CustomTool", summary: '{"foo":"bar"}', detail: undefined },
+    });
+  });
+
+  it("yields Bash tool with truncated command when no description", async () => {
+    const longCommand = "a".repeat(80);
+    async function* fakeStream(): AsyncGenerator<Chunk> {
+      yield {
+        type: "tool-call",
+        toolName: "Bash",
+        input: { command: longCommand },
+      };
+    }
+
+    const mockBox = { agent: { stream: vi.fn().mockReturnValue(fakeStream()) } };
+    const events = await collectEvents(handleRun(mockBox as any, "run long cmd"));
+
+    const toolEvent = events.find((e) => e.type === "tool");
+    expect(toolEvent).toBeDefined();
+    if (toolEvent && toolEvent.type === "tool") {
+      expect(toolEvent.tool.name).toBe("Bash");
+      expect(toolEvent.tool.summary).toBe("a".repeat(57) + "...");
+      expect(toolEvent.tool.summary.length).toBe(60);
+      // No detail when there's no description (summary IS the command)
+      expect(toolEvent.tool.detail).toBeUndefined();
+    }
+  });
+
+  it("yields Grep tool event with pattern summary", async () => {
+    async function* fakeStream(): AsyncGenerator<Chunk> {
+      yield {
+        type: "tool-call",
+        toolName: "Grep",
+        input: { pattern: "TODO|FIXME", path: "/src" },
+      };
+    }
+
+    const mockBox = { agent: { stream: vi.fn().mockReturnValue(fakeStream()) } };
+    const events = await collectEvents(handleRun(mockBox as any, "find todos"));
+
+    expect(events).toContainEqual({
+      type: "tool",
+      tool: { name: "Grep", summary: "TODO|FIXME", detail: undefined },
+    });
+  });
+
+  it("defaults invalid todo status to pending", async () => {
+    async function* fakeStream(): AsyncGenerator<Chunk> {
+      yield {
+        type: "tool-call",
+        toolName: "TodoWrite",
+        input: {
+          todos: [{ content: "Task", status: "invalid_status" }],
+        },
+      };
+    }
+
+    const mockBox = { agent: { stream: vi.fn().mockReturnValue(fakeStream()) } };
+    const events = await collectEvents(handleRun(mockBox as any, "plan"));
+
+    const todoEvent = events.find((e) => e.type === "todo");
+    expect(todoEvent).toBeDefined();
+    if (todoEvent && todoEvent.type === "todo") {
+      expect(todoEvent.todos[0].status).toBe("pending");
+    }
+  });
+
+  it("yields tool event for EnterPlanMode", async () => {
+    async function* fakeStream(): AsyncGenerator<Chunk> {
+      yield {
+        type: "tool-call",
+        toolName: "EnterPlanMode",
+        input: {},
+      };
+    }
+
+    const mockBox = { agent: { stream: vi.fn().mockReturnValue(fakeStream()) } };
+    const events = await collectEvents(handleRun(mockBox as any, "plan this"));
+
+    expect(events).toContainEqual({
+      type: "tool",
+      tool: { name: "EnterPlanMode", summary: "Planning implementation", detail: undefined },
+    });
+  });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,4 +4,7 @@ export type {
   BoxREPLCommand,
   BoxREPLCommandHandler,
   BoxREPLCommandName,
+  AgentToolName,
+  TodoItem,
+  ToolCallSummary,
 } from "./repl/types.js";

--- a/packages/cli/src/repl/commands/run.ts
+++ b/packages/cli/src/repl/commands/run.ts
@@ -1,5 +1,68 @@
 import type { Box } from "@upstash/box";
-import type { BoxREPLEvent } from "../types.js";
+import type { BoxREPLEvent, TodoItem, ToolCallSummary } from "../types.js";
+
+/**
+ * Derive a human-readable one-liner from a tool call's name and input.
+ */
+export function getToolSummary(toolName: string, input: Record<string, unknown>): ToolCallSummary {
+  let summary: string;
+  let detail: string | undefined;
+
+  switch (toolName) {
+    case "Bash": {
+      const command = typeof input.command === "string" ? input.command : "";
+      const truncatedCmd = command.length > 60 ? command.slice(0, 57) + "..." : command;
+      summary = typeof input.description === "string" ? input.description : truncatedCmd;
+      // Always include the command as detail when a description is present
+      if (typeof input.description === "string" && command) {
+        detail = truncatedCmd;
+      }
+      break;
+    }
+    case "Read":
+    case "Edit":
+    case "Write": {
+      const filePath = typeof input.file_path === "string" ? input.file_path : "";
+      summary = filePath.split("/").pop() || filePath;
+      break;
+    }
+    case "Grep":
+    case "Glob":
+      summary = typeof input.pattern === "string" ? input.pattern : "";
+      break;
+    case "EnterPlanMode":
+      summary = "Planning implementation";
+      break;
+    default: {
+      const raw = JSON.stringify(input);
+      summary = raw.length > 60 ? raw.slice(0, 57) + "..." : raw;
+      break;
+    }
+  }
+
+  return { name: toolName, summary, detail };
+}
+
+const VALID_TODO_STATUSES = new Set(["pending", "in_progress", "completed"]);
+
+/**
+ * Parse and validate todo items from a TodoWrite tool call input.
+ */
+export function parseTodoItems(input: Record<string, unknown>): TodoItem[] {
+  if (!Array.isArray(input.todos)) return [];
+
+  return input.todos.map((item: unknown): TodoItem => {
+    const obj = item && typeof item === "object" ? (item as Record<string, unknown>) : {};
+    return {
+      content: typeof obj.content === "string" ? obj.content : "",
+      status:
+        typeof obj.status === "string" && VALID_TODO_STATUSES.has(obj.status)
+          ? (obj.status as TodoItem["status"])
+          : "pending",
+      activeForm: typeof obj.activeForm === "string" ? obj.activeForm : undefined,
+    };
+  });
+}
 
 /**
  * Run the agent with a prompt, streaming output as events.
@@ -12,6 +75,14 @@ export async function* handleRun(box: Box, prompt: string): AsyncGenerator<BoxRE
   for await (const chunk of box.agent.stream({ prompt })) {
     if (chunk.type === "text-delta") {
       yield { type: "stream", text: chunk.text };
+    } else if (chunk.type === "tool-call") {
+      if (chunk.toolName === "TodoWrite") {
+        const todos = parseTodoItems(chunk.input);
+        yield { type: "todo", todos };
+      } else {
+        const tool = getToolSummary(chunk.toolName, chunk.input);
+        yield { type: "tool", tool };
+      }
     }
   }
   yield { type: "stream", text: "\n" };

--- a/packages/cli/src/repl/terminal.ts
+++ b/packages/cli/src/repl/terminal.ts
@@ -34,6 +34,9 @@ export async function startRepl(box: Box): Promise<void> {
   // --- Spinner tracking ---
   let activeSpinnerStop: (() => void) | null = null;
 
+  // --- Todo checklist tracking ---
+  let todoLines = 0;
+
   function ensureSpinnerStopped() {
     if (activeSpinnerStop) {
       activeSpinnerStop();
@@ -140,7 +143,40 @@ export async function startRepl(box: Box): Promise<void> {
         ensureSpinnerStopped();
         process.stdout.write(event.text);
         break;
+      case "tool": {
+        ensureSpinnerStopped();
+        const { name, summary, detail } = event.tool;
+        if (name === "Bash") {
+          let line = dim("  ⚡ ") + yellow(name) + dim(": " + summary);
+          if (detail) {
+            line += dim("\n      $ " + detail);
+          }
+          console.log(line);
+        } else {
+          console.log(dim("  ⚡ ") + yellow(name) + dim("(" + summary + ")"));
+        }
+        break;
+      }
+      case "todo": {
+        ensureSpinnerStopped();
+        if (todoLines > 0) {
+          stdout.write(cursorUp(todoLines) + eraseDown);
+        }
+        for (const item of event.todos) {
+          if (item.status === "completed") {
+            console.log(green("  ✔") + " " + item.content);
+          } else if (item.status === "in_progress") {
+            console.log(cyan("  ◼") + " " + item.content);
+          } else {
+            console.log(dim("  ◻") + " " + item.content);
+          }
+        }
+        todoLines = event.todos.length;
+        break;
+      }
       case "command:complete": {
+        ensureSpinnerStopped();
+        todoLines = 0;
         const seconds = (event.durationMs / 1000).toFixed(1);
         console.log(dim(`\n  /${event.command} completed in ${seconds}s\n`));
         break;

--- a/packages/cli/src/repl/types.ts
+++ b/packages/cli/src/repl/types.ts
@@ -10,10 +10,40 @@ export type BoxREPLCommandName =
   | "delete"
   | "console";
 
+/** Known tool names from the agent stream */
+export type AgentToolName =
+  | "Bash"
+  | "Read"
+  | "Edit"
+  | "Write"
+  | "Grep"
+  | "Glob"
+  | "TodoWrite"
+  | "EnterPlanMode";
+
+/** A single todo item from a TodoWrite tool call */
+export interface TodoItem {
+  content: string;
+  status: "pending" | "in_progress" | "completed";
+  activeForm?: string;
+}
+
+/** Summary of a tool invocation for display */
+export interface ToolCallSummary {
+  /** Tool name, typed for known tools with fallback */
+  name: AgentToolName | (string & {});
+  /** Human-readable one-liner derived from the tool's key input */
+  summary: string;
+  /** Optional secondary detail (e.g. the raw command for Bash) */
+  detail?: string;
+}
+
 export type BoxREPLEvent =
   | { type: "log"; message: string }
   | { type: "error"; message: string }
   | { type: "stream"; text: string }
+  | { type: "tool"; tool: ToolCallSummary }
+  | { type: "todo"; todos: TodoItem[] }
   | { type: "command:start"; command: BoxREPLCommandName; args: string }
   | { type: "command:complete"; command: BoxREPLCommandName; durationMs: number }
   | { type: "command:not-found"; typed: string; suggestions: BoxREPLCommandName[] }


### PR DESCRIPTION
Stream tool-call chunks from the agent as typed events so the CLI and web UI can render what the agent is doing (Read, Bash, Grep, etc.) and display a live todo checklist.