### PR TITLE
fix: strip preamble text before JSON in responseSchema parsing

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -628,6 +628,9 @@ export class Box {
       const jsonMatch = jsonStr.match(/```(?:json)?\s*([\s\S]*?)```/);
       if (jsonMatch?.[1]) jsonStr = jsonMatch[1].trim();
 
+      const braceIndex = jsonStr.indexOf("{");
+      if (braceIndex > 0) jsonStr = jsonStr.slice(braceIndex);
+
       try {
         const parsed = JSON.parse(jsonStr);
         output = options.responseSchema.parse(parsed);


### PR DESCRIPTION
## Summary
- Fixes `box.agent.run({ responseSchema })` failing when the agent includes conversational text before the JSON object (e.g. `"Now I have everything I need.\n\n{\"snippets\":[...]}"`)
- After the existing markdown code fence strip, finds the first `{` and discards any leading non-JSON text so `JSON.parse` succeeds

## Test plan
- [ ] Call `box.agent.run()` with a `responseSchema` where the agent returns preamble text before JSON — should now parse successfully
- [ ] Verify clean JSON-only responses still parse correctly (no regression)
- [ ] Verify code-fenced JSON responses still parse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)