### PR TITLE
DX-2477: handle Ctrl+C AbortError in REPL prompt gracefully

### DIFF
--- a/.changeset/new-stars-fry.md
+++ b/.changeset/new-stars-fry.md
@@ -1,0 +1,5 @@
+---
+"@upstash/box-cli": patch
+---
+
+handle Ctrl+C AbortError in REPL prompt gracefully

--- a/packages/cli/src/repl/terminal.ts
+++ b/packages/cli/src/repl/terminal.ts
@@ -375,14 +375,25 @@ export async function startRepl(box: Box, options?: BoxREPLClientOptions): Promi
         setImmediate(() => showGhost(suggestion));
       }
 
-      const firstLine = await rl.question(currentPrompt);
+      let firstLine: string;
+      try {
+        firstLine = await rl.question(currentPrompt);
+      } catch (err) {
+        if (err instanceof Error && err.name === "AbortError") break;
+        throw err;
+      }
       inputLines.push(firstLine);
 
       if (isMetaReturn && stdin.isTTY) {
         while (true) {
           isMetaReturn = false;
-          const nextLine = await rl.question(continuationPrompt);
-          inputLines.push(nextLine);
+          try {
+            const nextLine = await rl.question(continuationPrompt);
+            inputLines.push(nextLine);
+          } catch (err) {
+            if (err instanceof Error && err.name === "AbortError") break;
+            throw err;
+          }
           if (!isMetaReturn) break;
         }
       }


### PR DESCRIPTION
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>