### PR TITLE
DX-2478: use _request instead of exec.command for box.cd

### DIFF
--- a/.changeset/grumpy-toes-grow.md
+++ b/.changeset/grumpy-toes-grow.md
@@ -1,0 +1,5 @@
+---
+"@upstash/box": patch
+---
+
+send box.cd with \_request instead of exec.command

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1062,9 +1062,11 @@ export class Box {
       newPath = Box._normalizePath(`${this._cwd}/${path}`);
     }
 
-    const result = await this.exec.command(`ls ${newPath}`);
+    const result = await this._request<ExecResult>("POST", `/v2/box/${this.id}/exec`, {
+      body: { command: ["ls", newPath] },
+    });
 
-    if (result._status === "failed") {
+    if (result.exit_code !== 0) {
       throw new BoxError(`cd: ${path}: No such file or directory`);
     }
 


### PR DESCRIPTION
exec.command added a folder to the request which broke the requests