### PR TITLE
feat(sdk): add timeout and agent options to schedule API

### DIFF
--- a/.changeset/orange-socks-write.md
+++ b/.changeset/orange-socks-write.md
@@ -1,0 +1,5 @@
+---
+"@upstash/box": minor
+---
+
+add timeout and agent options to schedule API

--- a/.changeset/orange-socks-write.md
+++ b/.changeset/orange-socks-write.md
@@ -1,5 +1,5 @@
 ---
-"@upstash/box": minor
+"@upstash/box": patch
 ---
 
 add timeout and agent options to schedule API

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -192,6 +192,8 @@ const execSchedule = await box.schedule.exec({
 const agentSchedule = await box.schedule.agent({
   cron: "0 9 * * *",
   prompt: "Run the test suite and fix any failures",
+  timeout: 300_000, // 5 minute timeout per run
+  options: { maxBudgetUsd: 1.0, effort: "high" }, // agent options (provider-specific)
 });
 
 // List all active and paused schedules.

--- a/packages/sdk/src/__tests__/box-schedule.test.ts
+++ b/packages/sdk/src/__tests__/box-schedule.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { mockResponse, createTestBox } from "./helpers.js";
+import { Agent } from "../types.js";
 
 describe("Box schedule operations", () => {
   afterEach(() => vi.restoreAllMocks());
@@ -137,6 +138,98 @@ describe("Box schedule operations", () => {
       expect(body.folder).toBe("/workspace/app");
       expect(body.webhook_url).toBe("https://example.com/hook");
       expect(body.webhook_headers).toEqual({ "x-key": "val" });
+    });
+
+    it("sends timeout when provided", async () => {
+      const { box, fetchMock } = await createTestBox();
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({
+          id: "sched-2",
+          box_id: "box-123",
+          type: "prompt",
+          cron: "0 9 * * *",
+          prompt: "Run tests",
+          status: "active",
+          timeout: 300000,
+          total_runs: 0,
+          total_failures: 0,
+          created_at: 1710000000,
+          updated_at: 1710000000,
+        }),
+      );
+
+      await box.schedule.agent({
+        cron: "0 9 * * *",
+        prompt: "Run tests",
+        timeout: 300000,
+      });
+
+      const body = JSON.parse(fetchMock.mock.calls[1]![1]?.body as string);
+      expect(body.timeout).toBe(300000);
+    });
+
+    it("sends agent_options when provided", async () => {
+      const { box, fetchMock } = await createTestBox<Agent.ClaudeCode>();
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({
+          id: "sched-2",
+          box_id: "box-123",
+          type: "prompt",
+          cron: "0 9 * * *",
+          prompt: "Run tests",
+          status: "active",
+          total_runs: 0,
+          total_failures: 0,
+          created_at: 1710000000,
+          updated_at: 1710000000,
+        }),
+      );
+
+      await box.schedule.agent({
+        cron: "0 9 * * *",
+        prompt: "Run tests",
+        options: {
+          maxTurns: 5,
+          maxBudgetUsd: 1.0,
+          effort: "high",
+          systemPrompt: "You are a test runner",
+        },
+      });
+
+      const body = JSON.parse(fetchMock.mock.calls[1]![1]?.body as string);
+      expect(body.agent_options).toEqual({
+        maxTurns: 5,
+        maxBudgetUsd: 1.0,
+        effort: "high",
+        systemPrompt: "You are a test runner",
+      });
+    });
+
+    it("does not send timeout or agent_options when omitted", async () => {
+      const { box, fetchMock } = await createTestBox();
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({
+          id: "sched-2",
+          box_id: "box-123",
+          type: "prompt",
+          cron: "0 9 * * *",
+          prompt: "Run tests",
+          status: "active",
+          total_runs: 0,
+          total_failures: 0,
+          created_at: 1710000000,
+          updated_at: 1710000000,
+        }),
+      );
+
+      await box.schedule.agent({
+        cron: "0 9 * * *",
+        prompt: "Run tests",
+      });
+
+      const body = JSON.parse(fetchMock.mock.calls[1]![1]?.body as string);
+      expect(body.timeout).toBeUndefined();
+      expect(body.agent_options).toBeUndefined();
     });
   });
 

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -316,7 +316,7 @@ export class Box<TProvider = unknown> {
   /** Schedule operations namespace */
   readonly schedule: {
     exec: (options: ExecScheduleOptions) => Promise<Schedule>;
-    agent: (options: AgentScheduleOptions) => Promise<Schedule>;
+    agent: (options: AgentScheduleOptions<TProvider>) => Promise<Schedule>;
     list: () => Promise<Schedule[]>;
     get: (id: string) => Promise<Schedule>;
     pause: (id: string) => Promise<void>;
@@ -1826,7 +1826,7 @@ export class Box<TProvider = unknown> {
     return this._request<Schedule>("POST", `/v2/box/${this.id}/schedules`, { body });
   }
 
-  private async _scheduleAgent(options: AgentScheduleOptions): Promise<Schedule> {
+  private async _scheduleAgent(options: AgentScheduleOptions<TProvider>): Promise<Schedule> {
     const body: Record<string, unknown> = {
       type: "prompt",
       cron: options.cron,
@@ -1834,6 +1834,9 @@ export class Box<TProvider = unknown> {
       folder: options.folder ? this._resolvePath(options.folder) : this._cwd,
     };
     if (options.model) body.model = options.model;
+    if (options.options)
+      body.agent_options = toBackendAgentOptions(this._agent, options.options);
+    if (options.timeout) body.timeout = options.timeout;
     if (options.webhookUrl) body.webhook_url = options.webhookUrl;
     if (options.webhookHeaders) body.webhook_headers = options.webhookHeaders;
     return this._request<Schedule>("POST", `/v2/box/${this.id}/schedules`, { body });

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1834,8 +1834,7 @@ export class Box<TProvider = unknown> {
       folder: options.folder ? this._resolvePath(options.folder) : this._cwd,
     };
     if (options.model) body.model = options.model;
-    if (options.options)
-      body.agent_options = toBackendAgentOptions(this._agent, options.options);
+    if (options.options) body.agent_options = toBackendAgentOptions(this._agent, options.options);
     if (options.timeout) body.timeout = options.timeout;
     if (options.webhookUrl) body.webhook_url = options.webhookUrl;
     if (options.webhookHeaders) body.webhook_headers = options.webhookHeaders;

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -752,7 +752,7 @@ export interface ExecScheduleOptions {
 /**
  * Options for creating a prompt schedule
  */
-export interface AgentScheduleOptions {
+export interface AgentScheduleOptions<TProvider = unknown> {
   /** Cron expression (e.g. "0 9 * * *"). UTC. */
   cron: string;
   /** The prompt/task for the AI agent */
@@ -761,6 +761,10 @@ export interface AgentScheduleOptions {
   folder?: string;
   /** Model override. Defaults to the box's configured model. */
   model?: string;
+  /** SDK-specific options forwarded to the underlying agent */
+  options?: AgentOptions<TProvider>;
+  /** Timeout in milliseconds — kills the run if exceeded */
+  timeout?: number;
   /** URL to POST results to after each run */
   webhookUrl?: string;
   /** Custom headers sent with webhook */
@@ -780,6 +784,8 @@ export interface Schedule {
   prompt?: string;
   folder?: string;
   model?: string;
+  agent_options?: Record<string, unknown>;
+  timeout?: number;
   status: ScheduleStatus;
   qstash_schedule_id?: string;
   webhook_url?: string;


### PR DESCRIPTION
## Summary
- Add `timeout` and `options` (provider-specific agent options) to `AgentScheduleOptions`
- Add `agent_options` and `timeout` fields to `Schedule` response type
- Serialize both fields in `_scheduleAgent` using existing `toBackendAgentOptions` helper
- Add 3 new tests covering timeout, agent_options, and omission

## Test plan
- [x] All 274 existing tests pass
- [x] New tests: sends timeout, sends agent_options (ClaudeCode provider), omits both when not provided


🤖 Generated with [Claude Code](https://claude.com/claude-code)