### PR TITLE
feat(sdk): add tool_use_id tracking and onToolResult callback

### DIFF
--- a/packages/sdk/src/__tests__/box-agent-run.test.ts
+++ b/packages/sdk/src/__tests__/box-agent-run.test.ts
@@ -29,12 +29,12 @@ describe("box.agent.run", () => {
 
   it("calls onToolUse callback", async () => {
     const { box, fetchMock } = await createTestBox();
-    const tools: Array<{ name: string; input: Record<string, unknown> }> = [];
+    const tools: Array<{ id: string; name: string; input: Record<string, unknown> }> = [];
 
     fetchMock.mockResolvedValueOnce(
       mockSSEResponse([
         { event: "run_start", data: { run_id: "r1" } },
-        { event: "tool", data: { name: "Read", input: { path: "/test" } } },
+        { event: "tool", data: { tool_use_id: "toolu_abc", name: "Read", input: { path: "/test" } } },
         { event: "done", data: {} },
       ]),
     );
@@ -45,7 +45,31 @@ describe("box.agent.run", () => {
     });
 
     expect(tools).toHaveLength(1);
+    expect(tools[0]!.id).toBe("toolu_abc");
     expect(tools[0]!.name).toBe("Read");
+  });
+
+  it("calls onToolResult callback", async () => {
+    const { box, fetchMock } = await createTestBox();
+    const results: Array<{ id: string; output: string }> = [];
+
+    fetchMock.mockResolvedValueOnce(
+      mockSSEResponse([
+        { event: "run_start", data: { run_id: "r1" } },
+        { event: "tool", data: { tool_use_id: "toolu_1", name: "Bash", input: { command: "ls" } } },
+        { event: "tool_result", data: { tool_use_id: "toolu_1", output: "file.txt" } },
+        { event: "done", data: {} },
+      ]),
+    );
+
+    await box.agent.run({
+      prompt: "test",
+      onToolResult: (result) => results.push(result),
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.id).toBe("toolu_1");
+    expect(results[0]!.output).toBe("file.txt");
   });
 
   it("parses structured output with responseSchema", async () => {
@@ -437,12 +461,12 @@ describe("box.agent.stream", () => {
 
   it("yields tool-call chunks and calls onToolUse", async () => {
     const { box, fetchMock } = await createTestBox();
-    const tools: Array<{ name: string; input: Record<string, unknown> }> = [];
+    const tools: Array<{ id: string; name: string; input: Record<string, unknown> }> = [];
 
     fetchMock.mockResolvedValueOnce(
       mockSSEResponse([
         { event: "run_start", data: { run_id: "r1" } },
-        { event: "tool", data: { name: "Write", input: { path: "/x" } } },
+        { event: "tool", data: { tool_use_id: "toolu_w1", name: "Write", input: { path: "/x" } } },
         { event: "text", data: { text: "done" } },
         { event: "done", data: {} },
       ]),
@@ -458,13 +482,51 @@ describe("box.agent.stream", () => {
     }
 
     expect(tools).toHaveLength(1);
+    expect(tools[0]!.id).toBe("toolu_w1");
     expect(tools[0]!.name).toBe("Write");
     const toolChunks = chunks.filter((c) => c.type === "tool-call");
     expect(toolChunks).toHaveLength(1);
+    expect((toolChunks[0] as Extract<Chunk, { type: "tool-call" }>).toolCallId).toBe("toolu_w1");
     const textChunks = chunks.filter(
       (c): c is Extract<Chunk, { type: "text-delta" }> => c.type === "text-delta",
     );
     expect(textChunks.map((c) => c.text)).toEqual(["done"]);
+  });
+
+  it("yields tool-result chunks with matching toolCallId", async () => {
+    const { box, fetchMock } = await createTestBox();
+    const results: Array<{ id: string; output: string }> = [];
+
+    fetchMock.mockResolvedValueOnce(
+      mockSSEResponse([
+        { event: "run_start", data: { run_id: "r1" } },
+        { event: "tool", data: { tool_use_id: "toolu_1", name: "Bash", input: { command: "ls" } } },
+        { event: "tool_result", data: { tool_use_id: "toolu_1", output: "file.txt" } },
+        { event: "done", data: {} },
+      ]),
+    );
+
+    const run = await box.agent.stream({
+      prompt: "test",
+      onToolResult: (result) => results.push(result),
+    });
+    const chunks: Chunk[] = [];
+    for await (const chunk of run) {
+      chunks.push(chunk);
+    }
+
+    const toolCall = chunks.find((c): c is Extract<Chunk, { type: "tool-call" }> => c.type === "tool-call");
+    expect(toolCall).toBeDefined();
+    expect(toolCall!.toolCallId).toBe("toolu_1");
+
+    const toolResult = chunks.find((c): c is Extract<Chunk, { type: "tool-result" }> => c.type === "tool-result");
+    expect(toolResult).toBeDefined();
+    expect(toolResult!.toolCallId).toBe("toolu_1");
+    expect(toolResult!.output).toBe("file.txt");
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.id).toBe("toolu_1");
+    expect(results[0]!.output).toBe("file.txt");
   });
 
   it("yields all chunk types in order", async () => {
@@ -475,7 +537,8 @@ describe("box.agent.stream", () => {
         { event: "run_start", data: { run_id: "r1" } },
         { event: "text", data: { text: "Hello " } },
         { event: "thinking", data: { text: "trace" } },
-        { event: "tool", data: { name: "Write", input: { path: "/x" } } },
+        { event: "tool", data: { tool_use_id: "toolu_w1", name: "Write", input: { path: "/x" } } },
+        { event: "tool_result", data: { tool_use_id: "toolu_w1", output: "ok" } },
         {
           event: "done",
           data: { output: "Hello world", input_tokens: 7, output_tokens: 9, session_id: "s1" },
@@ -495,6 +558,7 @@ describe("box.agent.stream", () => {
       "text-delta",
       "reasoning",
       "tool-call",
+      "tool-result",
       "finish",
       "stats",
     ]);

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -49,6 +49,18 @@ import type { ZodType } from "zod/v3";
 
 const DEFAULT_BASE_URL = "https://us-east-1.box.upstash.com";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- parsed JSON has no static type
+function extractToolCallId(parsed: any): string {
+  return (parsed.tool_use_id ?? parsed.id ?? "") as string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- parsed JSON has no static type
+function coerceToolOutput(parsed: any): string {
+  if (typeof parsed.output === "string") return parsed.output;
+  if (parsed.output == null) return "";
+  return JSON.stringify(parsed.output);
+}
+
 /** Infer the provider agent from a model string prefix. */
 export function inferDefaultProvider(model: string): Agent {
   if (model.startsWith("openrouter/")) return Agent.ClaudeCode;
@@ -826,7 +838,12 @@ export class Box<TProvider = unknown> {
             break;
           }
           case "tool": {
-            options.onToolUse?.({ name: parsed.name, input: parsed.input });
+            const toolCallId = extractToolCallId(parsed);
+            options.onToolUse?.({ id: toolCallId, name: parsed.name, input: parsed.input });
+            break;
+          }
+          case "tool_result": {
+            options.onToolResult?.({ id: extractToolCallId(parsed), output: coerceToolOutput(parsed) });
             break;
           }
           case "done": {
@@ -978,12 +995,25 @@ export class Box<TProvider = unknown> {
             return null;
           }
           case "tool": {
+            const toolCallId = extractToolCallId(parsed);
             const chunk: Chunk = {
               type: "tool-call",
+              toolCallId,
               toolName: parsed.name ?? "",
               input: parsed.input ?? {},
             };
-            options.onToolUse?.({ name: parsed.name ?? "", input: parsed.input ?? {} });
+            options.onToolUse?.({ id: toolCallId, name: parsed.name ?? "", input: parsed.input ?? {} });
+            return chunk;
+          }
+          case "tool_result": {
+            const toolCallId = extractToolCallId(parsed);
+            const output = coerceToolOutput(parsed);
+            const chunk: Chunk = {
+              type: "tool-result",
+              toolCallId,
+              output,
+            };
+            options.onToolResult?.({ id: toolCallId, output });
             return chunk;
           }
           case "done": {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -31,6 +31,8 @@ export type {
   PromptFiles,
   RunOptions,
   StreamOptions,
+  ToolUseEvent,
+  ToolResultEvent,
   Chunk,
   RunStatus,
   RunCost,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -381,11 +381,23 @@ export interface WebhookConfig {
   headers?: Record<string, string>;
 }
 
+export interface ToolUseEvent {
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+export interface ToolResultEvent {
+  id: string;
+  output: string;
+}
+
 export type Chunk =
   | { type: "start"; runId: string }
   | { type: "text-delta"; text: string }
   | { type: "reasoning"; text: string }
-  | { type: "tool-call"; toolName: string; input: Record<string, unknown> }
+  | { type: "tool-call"; toolCallId: string; toolName: string; input: Record<string, unknown> }
+  | { type: "tool-result"; toolCallId: string; output: string }
   | {
       type: "finish";
       output: string;
@@ -431,7 +443,9 @@ export interface StreamOptions<TProvider = unknown> {
   /** Timeout in milliseconds — aborts if exceeded */
   timeout?: number;
   /** Tool use callback — called when the agent invokes a tool (Read, Write, Bash, etc.) */
-  onToolUse?: (tool: { name: string; input: Record<string, unknown> }) => void;
+  onToolUse?: (tool: ToolUseEvent) => void;
+  /** Tool result callback — called when a tool invocation completes */
+  onToolResult?: (result: ToolResultEvent) => void;
 }
 
 /**
@@ -451,7 +465,9 @@ export interface RunOptions<T = undefined, TProvider = unknown> {
   /** Retries with exponential backoff on transient failures */
   maxRetries?: number;
   /** Tool use callback — called when the agent invokes a tool (Read, Write, Bash, etc.) */
-  onToolUse?: (tool: { name: string; input: Record<string, unknown> }) => void;
+  onToolUse?: (tool: ToolUseEvent) => void;
+  /** Tool result callback — called when a tool invocation completes */
+  onToolResult?: (result: ToolResultEvent) => void;
   /** Webhook — fire-and-forget, POST to URL on completion */
   webhook?: WebhookConfig;
 }


### PR DESCRIPTION
## Summary
- Add `toolCallId` (from `tool_use_id`) to tool-call events and streaming chunks so consumers can identify individual tool invocations
- Introduce new `tool_result` SSE event type with `onToolResult` callback and `tool-result` chunk, enabling correlation of tool invocations with their outputs
- Export new `ToolUseEvent` and `ToolResultEvent` types for typed callback signatures

## Test plan
- [x] Updated existing `onToolUse` tests to verify `id` field is populated from `tool_use_id`
- [x] Added new test for `onToolResult` callback in `box.agent.run`
- [x] Added new test for `tool-result` chunks and `onToolResult` in `box.agent.stream`
- [x] Updated chunk ordering test to include `tool-result` event