### PR TITLE
feat(sdk): add alpine/debian runtime variants

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -51,7 +51,7 @@ box create \
 | Flag               | Description                                                                                 | Default           |
 | ------------------ | ------------------------------------------------------------------------------------------- | ----------------- |
 | `--token`          | Upstash Box API token                                                                       |                   |
-| `--runtime`        | Runtime environment (`node`, `python`, `golang`, `ruby`, `rust`)                            |                   |
+| `--runtime`        | Runtime environment (`node`, `python`, `golang`, `ruby`, `rust`). Append `-alpine` for Alpine variants or `-debian` to be explicit (default). |                   |
 | `--agent-model`    | Agent model identifier                                                                      |                   |
 | `--agent-provider` | Agent provider (`claude-code`, `codex`, `opencode`) — inferred from model prefix if omitted | inferred          |
 | `--agent-api-key`  | Agent API key — omit for Upstash-managed key, `stored` for a saved key, or a direct API key | Upstash           |

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -353,7 +353,17 @@ const box = await Box.fromSnapshot("snap_abc123", { size: "medium" });
 
 ## Runtimes
 
-`Runtime` is a string union type: `"node" | "python" | "golang" | "ruby" | "rust"`
+Each runtime defaults to **Debian** (glibc, wider binary compatibility). Append `-alpine` for smaller images using musl.
+
+| Runtime     | Default (Debian)  | Alpine variant     |
+|-------------|-------------------|--------------------|
+| Node.js     | `"node"`          | `"node-alpine"`    |
+| Python      | `"python"`        | `"python-alpine"`  |
+| Go          | `"golang"`        | `"golang-alpine"`  |
+| Ruby        | `"ruby"`          | `"ruby-alpine"`    |
+| Rust        | `"rust"`          | `"rust-alpine"`    |
+
+You can also use explicit `-debian` suffixes (e.g. `"node-debian"`), which are equivalent to the base names.
 
 ## Examples
 

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -3,7 +3,12 @@ import type { ZodType } from "zod/v3";
 /**
  * Runtime environments available for boxes
  */
-export type Runtime = "node" | "python" | "golang" | "ruby" | "rust";
+export type Runtime =
+  | "node" | "node-alpine" | "node-debian"
+  | "python" | "python-alpine" | "python-debian"
+  | "golang" | "golang-alpine" | "golang-debian"
+  | "ruby" | "ruby-alpine" | "ruby-debian"
+  | "rust" | "rust-alpine" | "rust-debian";
 
 /**
  * Resource size presets for boxes.


### PR DESCRIPTION
## Summary
- Expand `Runtime` type to include `-alpine` and `-debian` suffixes for all runtimes (node, python, golang, ruby, rust)
- Document runtime variants and defaults (Debian) in SDK and CLI READMEs

## Test plan
- [ ] Verify TypeScript compilation passes with expanded Runtime type
- [ ] Check that existing code using base runtime names (`"node"`, `"python"`, etc.) still compiles
- [ ] Confirm README tables render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)