### PR TITLE
DX-2599: fix CLI global install (pnpm peer-dep zod mismatch)

### DIFF
--- a/.changeset/fix-cli-global-install.md
+++ b/.changeset/fix-cli-global-install.md
@@ -1,0 +1,7 @@
+---
+"@upstash/box-cli": patch
+---
+
+fix: make CLI self-contained so global install (`pnpm add -g`) works
+
+Move `@upstash/box` from `peerDependencies` to `dependencies` and add `zod` as a direct dependency. When installed globally via pnpm, peer dep resolution could pick up an older `zod` (e.g. `3.24.2`) from the shared global store, which lacks the `zod/v3` subpath that `zod-to-json-schema@^3.25.1` requires, causing `ERR_PACKAGE_PATH_NOT_EXPORTED` on startup.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,16 +34,15 @@
   "author": "Upstash",
   "license": "MIT",
   "dependencies": {
+    "@upstash/box": "workspace:*",
     "commander": "^13.0.0",
-    "dotenv": "^17.3.1"
+    "dotenv": "^17.3.1",
+    "zod": "^3.25.28"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",
     "prettier": "^3.8.1",
     "typescript": "^5.3.0"
-  },
-  "peerDependencies": {
-    "@upstash/box": "workspace:*"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       dotenv:
         specifier: ^17.3.1
         version: 17.3.1
+      zod:
+        specifier: ^3.25.28
+        version: 3.25.76
     devDependencies:
       '@types/node':
         specifier: ^20.10.0
@@ -1013,6 +1016,9 @@ packages:
     peerDependencies:
       zod: ^3.25 || ^4
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
@@ -1846,5 +1852,7 @@ snapshots:
   zod-to-json-schema@3.25.1(zod@4.3.6):
     dependencies:
       zod: 4.3.6
+
+  zod@3.25.76: {}
 
   zod@4.3.6: {}


### PR DESCRIPTION
## Summary
- Global `pnpm add -g @upstash/box-cli` crashed on startup with `ERR_PACKAGE_PATH_NOT_EXPORTED: './v3' is not defined by "exports" in .../zod/package.json`.
- Root cause: the CLI had `@upstash/box` as a `peerDependency`, and the SDK's `zod` peer range (`^3.25.0 || ^4.0.0`) got satisfied by an older `zod@3.24.2` already present in pnpm's shared global store from other global packages. `zod-to-json-schema@3.25.2` imports `zod/v3` — a subpath only added in zod `3.25+` — so loading the CLI blew up.
- Fix: move `@upstash/box` from `peerDependencies` to `dependencies` and add `zod: ^3.25.28` as a direct dep of the CLI. A binary shouldn't leave its runtime libs to peer resolution.

## Verified
Installed the packed tarball three ways and confirmed `box --version` works (previously only pnpm global failed, but all three are now verified clean):
- `pnpm add -g <tarball>`
- `npm install -g <tarball>`
- `bun add -g <tarball>`

After the fix pnpm resolves `zod-to-json-schema@3.25.2_zod@3.25.76` in the global store (was `_zod@3.24.2`).