### PR TITLE
add toolCallid and firstclass toolresult event #122

### DIFF
--- a/.changeset/loose-adults-glow.md
+++ b/.changeset/loose-adults-glow.md
@@ -1,0 +1,5 @@
+---
+"@upstash/box": patch
+---
+
+add toolCallId and first class tool result event to streaming chunks #122

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1094,12 +1094,24 @@ export class Box<TProvider = unknown> {
             return null;
           }
           case "tool": {
+            const toolCallId =
+              parsed.tool_call_id ?? parsed.id ?? parsed.tool_use_id ?? parsed.toolCallId ?? "";
             const chunk: Chunk = {
               type: "tool-call",
+              toolCallId,
               toolName: parsed.name ?? "",
               input: parsed.input ?? {},
             };
             options.onToolUse?.({ name: parsed.name ?? "", input: parsed.input ?? {} });
+            return chunk;
+          }
+          case "tool_result": {
+            const chunk: Chunk = {
+              type: "tool-result",
+              toolCallId:
+                parsed.tool_call_id ?? parsed.id ?? parsed.tool_use_id ?? parsed.toolCallId ?? "",
+              output: parsed.output,
+            };
             return chunk;
           }
           case "done": {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -426,7 +426,8 @@ export type Chunk =
   | { type: "start"; runId: string }
   | { type: "text-delta"; text: string }
   | { type: "reasoning"; text: string }
-  | { type: "tool-call"; toolName: string; input: Record<string, unknown> }
+  | { type: "tool-call"; toolCallId: string; toolName: string; input: Record<string, unknown> }
+  | { type: "tool-result"; toolCallId: string; output: unknown }
   | {
       type: "finish";
       output: string;


### PR DESCRIPTION
Closes #122.

This PR addresses the issue with parallel tool calls by:
1. Adding `toolCallId` to the `tool-call` chunk variant in `types.ts`
2. Introducing a first class `tool-result` chunk variant
3. Updating the `processEvent` parser in `client.ts` to properly extract the tool call IDs and map incoming `tool_result` events to the new chunk type instead of falling back to the Unknown type
and all tests n type checks are passing locally