### PR TITLE
auto wake idle boxes before file operations (#116)

### DIFF
--- a/packages/sdk/src/__tests__/box-files.test.ts
+++ b/packages/sdk/src/__tests__/box-files.test.ts
@@ -1,50 +1,63 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { mockResponse, createTestBox } from "./helpers.js";
 
+/** Matches `_ensureAwake()` → `_execCommand("pwd")` before file API calls */
+function mockWakeExec(): Response {
+  return mockResponse({ exit_code: 0, output: "/workspace/home\n" });
+}
+
 describe("Box file operations", () => {
   afterEach(() => vi.restoreAllMocks());
 
   describe("files.read", () => {
     it("reads a file with relative path", async () => {
       const { box, fetchMock } = await createTestBox();
+      fetchMock.mockResolvedValueOnce(mockWakeExec());
       fetchMock.mockResolvedValueOnce(mockResponse({ content: "file content" }));
 
       const content = await box.files.read("app.ts");
       expect(content).toBe("file content");
 
-      const [url] = fetchMock.mock.calls[1]!;
+      const [wakeUrl, wakeInit] = fetchMock.mock.calls[1]!;
+      expect(String(wakeUrl)).toContain("/exec");
+      expect(JSON.parse(wakeInit?.body as string).command).toEqual(["sh", "-c", "pwd"]);
+
+      const [url] = fetchMock.mock.calls[2]!;
       expect(url).toContain(encodeURIComponent("/workspace/home/app.ts"));
     });
 
     it("reads a file with absolute path", async () => {
       const { box, fetchMock } = await createTestBox();
+      fetchMock.mockResolvedValueOnce(mockWakeExec());
       fetchMock.mockResolvedValueOnce(mockResponse({ content: "root file" }));
 
       const content = await box.files.read("/etc/config");
       expect(content).toBe("root file");
 
-      const [url] = fetchMock.mock.calls[1]!;
+      const [url] = fetchMock.mock.calls[2]!;
       expect(url).toContain(encodeURIComponent("/etc/config"));
     });
 
     it("reads a file with base64 encoding", async () => {
       const { box, fetchMock } = await createTestBox();
+      fetchMock.mockResolvedValueOnce(mockWakeExec());
       fetchMock.mockResolvedValueOnce(mockResponse({ content: "aGVsbG8=" }));
 
       const content = await box.files.read("image.png", { encoding: "base64" });
       expect(content).toBe("aGVsbG8=");
 
-      const [url] = fetchMock.mock.calls[1]!;
+      const [url] = fetchMock.mock.calls[2]!;
       expect(url).toContain("encoding=base64");
     });
 
     it("does not send encoding param when not specified", async () => {
       const { box, fetchMock } = await createTestBox();
+      fetchMock.mockResolvedValueOnce(mockWakeExec());
       fetchMock.mockResolvedValueOnce(mockResponse({ content: "plain" }));
 
       await box.files.read("file.txt");
 
-      const [url] = fetchMock.mock.calls[1]!;
+      const [url] = fetchMock.mock.calls[2]!;
       expect(url).not.toContain("encoding");
     });
   });
@@ -52,11 +65,12 @@ describe("Box file operations", () => {
   describe("files.write", () => {
     it("writes a file with relative path", async () => {
       const { box, fetchMock } = await createTestBox();
+      fetchMock.mockResolvedValueOnce(mockWakeExec());
       fetchMock.mockResolvedValueOnce(mockResponse({}));
 
       await box.files.write({ path: "hello.txt", content: "hello" });
 
-      const [url, init] = fetchMock.mock.calls[1]!;
+      const [url, init] = fetchMock.mock.calls[2]!;
       expect(url).toContain("/files/write");
       const body = JSON.parse(init?.body as string);
       expect(body.path).toBe("/workspace/home/hello.txt");
@@ -65,11 +79,12 @@ describe("Box file operations", () => {
 
     it("writes a file with absolute path", async () => {
       const { box, fetchMock } = await createTestBox();
+      fetchMock.mockResolvedValueOnce(mockWakeExec());
       fetchMock.mockResolvedValueOnce(mockResponse({}));
 
       await box.files.write({ path: "/tmp/test.txt", content: "data" });
 
-      const body = JSON.parse(fetchMock.mock.calls[1]![1]?.body as string);
+      const body = JSON.parse(fetchMock.mock.calls[2]![1]?.body as string);
       expect(body.path).toBe("/tmp/test.txt");
     });
   });
@@ -87,6 +102,7 @@ describe("Box file operations", () => {
           mod_time: "",
         },
       ];
+      fetchMock.mockResolvedValueOnce(mockWakeExec());
       fetchMock.mockResolvedValueOnce(mockResponse({ files }));
 
       const result = await box.files.list(".");
@@ -96,12 +112,13 @@ describe("Box file operations", () => {
 
     it("lists files without path", async () => {
       const { box, fetchMock } = await createTestBox();
+      fetchMock.mockResolvedValueOnce(mockWakeExec());
       fetchMock.mockResolvedValueOnce(mockResponse({ files: [] }));
 
       const result = await box.files.list();
       expect(result).toEqual([]);
 
-      const [url] = fetchMock.mock.calls[1]!;
+      const [url] = fetchMock.mock.calls[2]!;
       expect(url).not.toContain("path=");
     });
   });

--- a/packages/sdk/src/__tests__/ephemeral-box.test.ts
+++ b/packages/sdk/src/__tests__/ephemeral-box.test.ts
@@ -283,6 +283,9 @@ describe("EphemeralBox instance", () => {
   it("delegates files.read to the internal box", async () => {
     const box = await createBox();
 
+    vi.mocked(fetch).mockResolvedValueOnce(
+      mockResponse({ exit_code: 0, output: "/workspace/home\n" }),
+    );
     vi.mocked(fetch).mockResolvedValueOnce(mockResponse({ content: "file content" }));
 
     const content = await box.files.read("test.txt");

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1652,7 +1652,12 @@ export class Box<TProvider = unknown> {
     return `${this._cwd}/${p}`;
   }
 
+  private async _ensureAwake(): Promise<void> {
+    await this._execCommand("pwd").catch(() => {});
+  }
+
   private async _readFile(path: string, encoding?: "base64"): Promise<string> {
+    await this._ensureAwake();
     const resolved = this._resolvePath(path);
     let url = `/v2/box/${this.id}/files/read?path=${encodeURIComponent(resolved)}`;
     if (encoding) url += `&encoding=${encodeURIComponent(encoding)}`;
@@ -1661,6 +1666,7 @@ export class Box<TProvider = unknown> {
   }
 
   private async _writeFile(path: string, content: string, encoding?: "base64"): Promise<void> {
+    await this._ensureAwake();
     const resolved = this._resolvePath(path);
     await this._request("POST", `/v2/box/${this.id}/files/write`, {
       body: { path: resolved, content, ...(encoding && { encoding }) },
@@ -1668,6 +1674,7 @@ export class Box<TProvider = unknown> {
   }
 
   private async _listFiles(path?: string): Promise<FileEntry[]> {
+    await this._ensureAwake();
     let qs = "";
     if (path) {
       const resolved = this._resolvePath(path);
@@ -1684,6 +1691,7 @@ export class Box<TProvider = unknown> {
   }
 
   private async _uploadFiles(files: UploadFileEntry[]): Promise<void> {
+    await this._ensureAwake();
     const fs = await this._getFs();
 
     const formData = new FormData();
@@ -1709,6 +1717,7 @@ export class Box<TProvider = unknown> {
   }
 
   private async _downloadFiles(remotePath?: string): Promise<void> {
+    await this._ensureAwake();
     const fs = await this._getFs();
     const path = await this._getPath();
 


### PR DESCRIPTION
Closes #116

File ops were failing on idle boxes so I added a quick silent `pwd` exec (`_ensureAwake()`) right before any file method to force the box to wake up transparently