### PR TITLE
chore: use public CLI repository metadata

### DIFF
--- a/.changeset/public-cli-repository-metadata.md
+++ b/.changeset/public-cli-repository-metadata.md
@@ -1,0 +1,5 @@
+---
+"@upstash/box-cli": patch
+---
+
+Use public HTTPS repository metadata for the CLI package.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,7 +4,7 @@
   "description": "CLI for Upstash Box — REPL-first interface for AI coding agents",
   "repository": {
     "type": "git",
-    "url": "git@github.com:upstash/box.git"
+    "url": "git+https://github.com/upstash/box.git"
   },
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- update `@upstash/box-cli` repository metadata from the SSH-style GitHub URL to the public HTTPS Git URL
- add a patch changeset so the metadata update can be published with the CLI package
- leave runtime code, dependencies, package version, entry points, homepage, bugs metadata, and package contents unchanged

## Validation
- `npm view @upstash/box-cli --json`
- checked for duplicate upstream PRs and Charles microbounty records before submission
- metadata and changeset assertion with Node.js
- `COREPACK_ENABLE_PROJECT_SPEC=0 pnpm install --frozen-lockfile --ignore-scripts`
- `COREPACK_ENABLE_PROJECT_SPEC=0 pnpm --filter @upstash/box-cli... build`
- `COREPACK_ENABLE_PROJECT_SPEC=0 pnpm --filter @upstash/box-cli ci:lint`
- `COREPACK_ENABLE_PROJECT_SPEC=0 pnpm --filter @upstash/box-cli test`
- `npm pack --dry-run --ignore-scripts --json .` from `packages/cli`
- `git diff --check`
