### PR TITLE
python-sdk: release 0.1.2 (add ClaudeCode.FABLE_5)

### DIFF
--- a/packages/python-sdk/CHANGELOG.md
+++ b/packages/python-sdk/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `upstash-box` (Python) are documented here.
 
+## 0.1.2
+
+- Add `ClaudeCode.FABLE_5` (`anthropic/claude-fable-5`) to the Claude Code model
+  options, mirroring `@upstash/box` 0.5.2.
+
 ## 0.1.1
 
 - Add Alpine runtime variants to the `Runtime` type: `node-alpine`,

--- a/packages/python-sdk/RELEASE.md
+++ b/packages/python-sdk/RELEASE.md
@@ -11,6 +11,7 @@ Each release records the JS feature level it reached parity with:
 | upstash-box (PyPI) | parity as of `@upstash/box` |
 | ------------------ | --------------------------- |
 | 0.1.0              | 0.5.0                       |
+| 0.1.2              | 0.5.2                       |
 
 When a JS feature is mirrored, bump the Python patch/minor version and update the
 row above (and `__version__` in `upstash_box/__init__.py` + `version` in

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "upstash-box"
-version = "0.1.1"
+version = "0.1.2"
 description = "Upstash Box SDK - Python client for async and parallel AI coding agents"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/python-sdk/upstash_box/__init__.py
+++ b/packages/python-sdk/upstash_box/__init__.py
@@ -107,7 +107,7 @@ from .types import (
     WebhookConfig,
 )
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 __all__ = [
     # Clients (sync canonical + async variants)


### PR DESCRIPTION
Prepares the `upstash-box` Python 0.1.2 release.

## What
- Bump version `0.1.1 → 0.1.2` (`pyproject.toml` + `upstash_box/__init__.py`)
- CHANGELOG `0.1.2` entry for `ClaudeCode.FABLE_5` (`anthropic/claude-fable-5`)
- RELEASE.md parity row: `0.1.2 → @upstash/box 0.5.2`

`FABLE_5` itself already landed in the enum via #189; this is the version bump + release metadata needed to publish it to PyPI.

## Verified locally (matches CI verify gate)
- parity check OK (JS ↔ Python)
- version consistency (pyproject == `__init__`)
- `generate_sync` clean, ruff check + format clean, mypy clean
- 145 tests pass (`tests/_async tests/_sync`)

## Release after merge
Tag the merge commit to trigger `python-sdk-publish.yml` (publishes only after `pypi` environment approval):

```
git tag python-sdk-v0.1.2
git push origin python-sdk-v0.1.2
```