### PR TITLE
DX-2986: add Claude Fable 5.1 and GPT-6 Astra, correct spark and nano picker entries

### DIFF
--- a/.changeset/olive-pandas-smile.md
+++ b/.changeset/olive-pandas-smile.md
@@ -1,0 +1,19 @@
+---
+"@upstash/box": patch
+"@upstash/box-cli": patch
+---
+
+Add Claude Fable 5.1, and correct two model picker entries.
+
+`Fable_5_1` is available on the Claude API, OpenRouter, Vercel AI Gateway and
+OpenCode Zen. Note the spelling differs by provider: the Claude API and Zen use
+`claude-fable-5-1`, while the OpenRouter and Vercel gateways list it as
+`claude-fable-5.1`.
+
+Removed `OpenAICodex.GPT_5_3_Codex_Spark` from the model picker. It is a ChatGPT
+research preview rather than an API model. The enum member is still exported, so
+this is not a breaking change; `OpenCodeModel.GPT_5_3_Codex_Spark` is unaffected
+because Zen does sell it.
+
+GPT-5 Nano moved from the free group to the paid group, since Zen now charges
+$0.05 / $0.40 per MTok for it.

--- a/.changeset/olive-pandas-smile.md
+++ b/.changeset/olive-pandas-smile.md
@@ -3,7 +3,10 @@
 "@upstash/box-cli": patch
 ---
 
-Add Claude Fable 5.1, and correct two model picker entries.
+Add GPT-6 Astra and Claude Fable 5.1, and correct two model picker entries.
+
+`GPT_6_Astra` is available on the OpenAI API, OpenRouter, the Vercel AI Gateway
+and OpenCode Zen, all at $10 / $50 per MTok.
 
 `Fable_5_1` is available on the Claude API, OpenRouter, Vercel AI Gateway and
 OpenCode Zen. Note the spelling differs by provider: the Claude API and Zen use

--- a/packages/cli/src/models.ts
+++ b/packages/cli/src/models.ts
@@ -77,7 +77,6 @@ export const MODEL_OPTIONS_BY_AGENT: Record<
         { value: OpenAICodex.GPT_5_4, label: "GPT-5.4" },
         { value: OpenAICodex.GPT_5_4_Mini, label: "GPT-5.4 Mini" },
         { value: OpenAICodex.GPT_5_3_Codex, label: "GPT-5.3 Codex" },
-        { value: OpenAICodex.GPT_5_3_Codex_Spark, label: "GPT-5.3 Codex Spark" },
         { value: OpenAICodex.GPT_5_2_Codex, label: "GPT-5.2 Codex" },
         { value: OpenAICodex.GPT_5_1_Codex_Max, label: "GPT-5.1 Codex Max" },
         { value: OpenAICodex.GPT_5_1_Codex_Mini, label: "GPT-5.1 Codex Mini" },
@@ -123,13 +122,13 @@ export const MODEL_OPTIONS_BY_AGENT: Record<
     {
       label: "OpenCode — Free",
       options: [
-        { value: OpenCodeModel.Zen_GPT_5_Nano, label: "GPT-5 Nano (Free)" },
         { value: OpenCodeModel.Zen_Big_Pickle, label: "Big Pickle (Free)" },
       ],
     },
     {
       label: "OpenCode — Paid",
       options: [
+        { value: OpenCodeModel.Zen_GPT_5_Nano, label: "GPT-5 Nano" },
         { value: OpenCodeModel.Zen_MiniMax_M2_7, label: "MiniMax M2.7" },
         { value: OpenCodeModel.Zen_Claude_Fable_5, label: "Claude Fable 5" },
         { value: OpenCodeModel.Zen_Claude_Opus_5, label: "Claude Opus 5" },

--- a/packages/cli/src/models.ts
+++ b/packages/cli/src/models.ts
@@ -17,6 +17,7 @@ export const MODEL_OPTIONS_BY_AGENT: Record<
     {
       label: "Anthropic",
       options: [
+        { value: ClaudeCode.Fable_5_1, label: "Claude Fable 5.1" },
         { value: ClaudeCode.Fable_5, label: "Claude Fable 5" },
         { value: ClaudeCode.Opus_5, label: "Claude Opus 5" },
         { value: ClaudeCode.Opus_4_8, label: "Claude Opus 4.8" },
@@ -33,6 +34,7 @@ export const MODEL_OPTIONS_BY_AGENT: Record<
     {
       label: "OpenRouter",
       options: [
+        { value: OpenRouterModel.Claude_Fable_5_1, label: "Claude Fable 5.1 (OR)" },
         { value: OpenRouterModel.Claude_Fable_5, label: "Claude Fable 5 (OR)" },
         { value: OpenRouterModel.Claude_Opus_5, label: "Claude Opus 5 (OR)" },
         { value: OpenRouterModel.Claude_Opus_4_5, label: "Claude Opus 4.5 (OR)" },
@@ -53,6 +55,7 @@ export const MODEL_OPTIONS_BY_AGENT: Record<
     {
       label: "Vercel AI Gateway",
       options: [
+        { value: VercelModel.Claude_Fable_5_1, label: "Claude Fable 5.1 (Vercel)" },
         { value: VercelModel.Claude_Fable_5, label: "Claude Fable 5 (Vercel)" },
         { value: VercelModel.Claude_Opus_5, label: "Claude Opus 5 (Vercel)" },
         { value: VercelModel.Claude_Sonnet_5, label: "Claude Sonnet 5 (Vercel)" },
@@ -85,6 +88,7 @@ export const MODEL_OPTIONS_BY_AGENT: Record<
     {
       label: "OpenRouter",
       options: [
+        { value: OpenRouterModel.Claude_Fable_5_1, label: "Claude Fable 5.1 (OR)" },
         { value: OpenRouterModel.Claude_Fable_5, label: "Claude Fable 5 (OR)" },
         { value: OpenRouterModel.Claude_Opus_5, label: "Claude Opus 5 (OR)" },
         { value: OpenRouterModel.Claude_Opus_4_5, label: "Claude Opus 4.5 (OR)" },
@@ -130,6 +134,7 @@ export const MODEL_OPTIONS_BY_AGENT: Record<
       options: [
         { value: OpenCodeModel.Zen_GPT_5_Nano, label: "GPT-5 Nano" },
         { value: OpenCodeModel.Zen_MiniMax_M2_7, label: "MiniMax M2.7" },
+        { value: OpenCodeModel.Zen_Claude_Fable_5_1, label: "Claude Fable 5.1" },
         { value: OpenCodeModel.Zen_Claude_Fable_5, label: "Claude Fable 5" },
         { value: OpenCodeModel.Zen_Claude_Opus_5, label: "Claude Opus 5" },
         { value: OpenCodeModel.Zen_Claude_Sonnet_5, label: "Claude Sonnet 5" },
@@ -150,6 +155,7 @@ export const MODEL_OPTIONS_BY_AGENT: Record<
     {
       label: "Anthropic",
       options: [
+        { value: OpenCodeModel.Claude_Fable_5_1, label: "Claude Fable 5.1" },
         { value: OpenCodeModel.Claude_Fable_5, label: "Claude Fable 5" },
         { value: OpenCodeModel.Claude_Opus_5, label: "Claude Opus 5" },
         { value: OpenCodeModel.Claude_Opus_4_8, label: "Claude Opus 4.8" },
@@ -184,6 +190,7 @@ export const MODEL_OPTIONS_BY_AGENT: Record<
     {
       label: "OpenRouter",
       options: [
+        { value: OpenRouterModel.Claude_Fable_5_1, label: "Claude Fable 5.1 (OR)" },
         { value: OpenRouterModel.Claude_Fable_5, label: "Claude Fable 5 (OR)" },
         { value: OpenRouterModel.Claude_Opus_5, label: "Claude Opus 5 (OR)" },
         { value: OpenRouterModel.Claude_Opus_4_5, label: "Claude Opus 4.5 (OR)" },
@@ -204,6 +211,7 @@ export const MODEL_OPTIONS_BY_AGENT: Record<
     {
       label: "Vercel AI Gateway",
       options: [
+        { value: VercelModel.Claude_Fable_5_1, label: "Claude Fable 5.1 (Vercel)" },
         { value: VercelModel.Claude_Fable_5, label: "Claude Fable 5 (Vercel)" },
         { value: VercelModel.Claude_Opus_5, label: "Claude Opus 5 (Vercel)" },
         { value: VercelModel.Claude_Sonnet_5, label: "Claude Sonnet 5 (Vercel)" },

--- a/packages/cli/src/models.ts
+++ b/packages/cli/src/models.ts
@@ -129,9 +129,7 @@ export const MODEL_OPTIONS_BY_AGENT: Record<
   [Agent.OpenCode]: [
     {
       label: "OpenCode — Free",
-      options: [
-        { value: OpenCodeModel.Zen_Big_Pickle, label: "Big Pickle (Free)" },
-      ],
+      options: [{ value: OpenCodeModel.Zen_Big_Pickle, label: "Big Pickle (Free)" }],
     },
     {
       label: "OpenCode — Paid",

--- a/packages/cli/src/models.ts
+++ b/packages/cli/src/models.ts
@@ -44,6 +44,7 @@ export const MODEL_OPTIONS_BY_AGENT: Record<
         { value: OpenRouterModel.DeepSeek_R1, label: "DeepSeek R1 (OR)" },
         { value: OpenRouterModel.Gemini_2_5_Pro, label: "Gemini 2.5 Pro (OR)" },
         { value: OpenRouterModel.Gemini_2_5_Flash, label: "Gemini 2.5 Flash (OR)" },
+        { value: OpenRouterModel.GPT_6_Astra, label: "GPT-6 Astra (OR)" },
         { value: OpenRouterModel.GPT_5_6_Sol, label: "GPT-5.6 Sol (OR)" },
         { value: OpenRouterModel.GPT_5_6_Terra, label: "GPT-5.6 Terra (OR)" },
         { value: OpenRouterModel.GPT_5_6_Luna, label: "GPT-5.6 Luna (OR)" },
@@ -73,6 +74,7 @@ export const MODEL_OPTIONS_BY_AGENT: Record<
     {
       label: "OpenAI",
       options: [
+        { value: OpenAICodex.GPT_6_Astra, label: "GPT-6 Astra" },
         { value: OpenAICodex.GPT_5_6_Sol, label: "GPT-5.6 Sol" },
         { value: OpenAICodex.GPT_5_6_Terra, label: "GPT-5.6 Terra" },
         { value: OpenAICodex.GPT_5_6_Luna, label: "GPT-5.6 Luna" },
@@ -98,6 +100,7 @@ export const MODEL_OPTIONS_BY_AGENT: Record<
         { value: OpenRouterModel.DeepSeek_R1, label: "DeepSeek R1 (OR)" },
         { value: OpenRouterModel.Gemini_2_5_Pro, label: "Gemini 2.5 Pro (OR)" },
         { value: OpenRouterModel.Gemini_2_5_Flash, label: "Gemini 2.5 Flash (OR)" },
+        { value: OpenRouterModel.GPT_6_Astra, label: "GPT-6 Astra (OR)" },
         { value: OpenRouterModel.GPT_5_6_Sol, label: "GPT-5.6 Sol (OR)" },
         { value: OpenRouterModel.GPT_5_6_Terra, label: "GPT-5.6 Terra (OR)" },
         { value: OpenRouterModel.GPT_5_6_Luna, label: "GPT-5.6 Luna (OR)" },
@@ -109,6 +112,7 @@ export const MODEL_OPTIONS_BY_AGENT: Record<
     {
       label: "Vercel AI Gateway",
       options: [
+        { value: VercelModel.GPT_6_Astra, label: "GPT-6 Astra (Vercel)" },
         { value: VercelModel.GPT_5_6_Sol, label: "GPT-5.6 Sol (Vercel)" },
         { value: VercelModel.GPT_5_6_Terra, label: "GPT-5.6 Terra (Vercel)" },
         { value: VercelModel.GPT_5_6_Luna, label: "GPT-5.6 Luna (Vercel)" },
@@ -172,6 +176,7 @@ export const MODEL_OPTIONS_BY_AGENT: Record<
     {
       label: "OpenAI",
       options: [
+        { value: OpenCodeModel.GPT_6_Astra, label: "GPT-6 Astra" },
         { value: OpenCodeModel.GPT_5_5, label: "GPT-5.5" },
         { value: OpenCodeModel.GPT_5_4_Pro, label: "GPT-5.4 Pro" },
         { value: OpenCodeModel.GPT_5_4, label: "GPT-5.4" },
@@ -200,6 +205,7 @@ export const MODEL_OPTIONS_BY_AGENT: Record<
         { value: OpenRouterModel.DeepSeek_R1, label: "DeepSeek R1 (OR)" },
         { value: OpenRouterModel.Gemini_2_5_Pro, label: "Gemini 2.5 Pro (OR)" },
         { value: OpenRouterModel.Gemini_2_5_Flash, label: "Gemini 2.5 Flash (OR)" },
+        { value: OpenRouterModel.GPT_6_Astra, label: "GPT-6 Astra (OR)" },
         { value: OpenRouterModel.GPT_5_6_Sol, label: "GPT-5.6 Sol (OR)" },
         { value: OpenRouterModel.GPT_5_6_Terra, label: "GPT-5.6 Terra (OR)" },
         { value: OpenRouterModel.GPT_5_6_Luna, label: "GPT-5.6 Luna (OR)" },

--- a/packages/python-sdk/upstash_box/types.py
+++ b/packages/python-sdk/upstash_box/types.py
@@ -49,6 +49,7 @@ class Agent(str, Enum):
 class ClaudeCode(str, Enum):
     """Claude Code model identifiers."""
 
+    FABLE_5_1 = "anthropic/claude-fable-5-1"
     FABLE_5 = "anthropic/claude-fable-5"
     OPUS_4_5 = "anthropic/claude-opus-4-5"
     OPUS_4_6 = "anthropic/claude-opus-4-6"
@@ -82,6 +83,7 @@ class OpenAICodex(str, Enum):
 class OpenRouterModel(str, Enum):
     """OpenRouter model identifiers — shared across agents that support OpenRouter."""
 
+    CLAUDE_FABLE_5_1 = "openrouter/anthropic/claude-fable-5.1"
     CLAUDE_FABLE_5 = "openrouter/anthropic/claude-fable-5"
     CLAUDE_OPUS_5 = "openrouter/anthropic/claude-opus-5"
     CLAUDE_SONNET_5 = "openrouter/anthropic/claude-sonnet-5"
@@ -102,6 +104,7 @@ class OpenRouterModel(str, Enum):
 class VercelModel(str, Enum):
     """Vercel AI Gateway model identifiers."""
 
+    CLAUDE_FABLE_5_1 = "vercel/anthropic/claude-fable-5.1"
     CLAUDE_FABLE_5 = "vercel/anthropic/claude-fable-5"
     CLAUDE_OPUS_5 = "vercel/anthropic/claude-opus-5"
     CLAUDE_SONNET_5 = "vercel/anthropic/claude-sonnet-5"
@@ -128,6 +131,7 @@ class OpenCodeModel(str, Enum):
     """OpenCode model identifiers — supports models from multiple providers."""
 
     # Anthropic-backed OpenCode models
+    CLAUDE_FABLE_5_1 = "opencode/claude-fable-5-1"
     CLAUDE_FABLE_5 = "opencode/claude-fable-5"
     CLAUDE_OPUS_5 = "opencode/claude-opus-5"
     CLAUDE_OPUS_4_5 = "opencode/claude-opus-4-5"
@@ -158,6 +162,7 @@ class OpenCodeModel(str, Enum):
     ZEN_BIG_PICKLE = "opencode/big-pickle"
     # Paid models
     ZEN_MINIMAX_M2_7 = "opencode/minimax-m2.7"
+    ZEN_CLAUDE_FABLE_5_1 = "opencode/claude-fable-5-1"
     ZEN_CLAUDE_FABLE_5 = "opencode/claude-fable-5"
     ZEN_CLAUDE_OPUS_5 = "opencode/claude-opus-5"
     ZEN_CLAUDE_SONNET_4_6 = "opencode/claude-sonnet-4-6"

--- a/packages/python-sdk/upstash_box/types.py
+++ b/packages/python-sdk/upstash_box/types.py
@@ -66,6 +66,7 @@ class ClaudeCode(str, Enum):
 class OpenAICodex(str, Enum):
     """OpenAI Codex model identifiers."""
 
+    GPT_6_ASTRA = "openai/gpt-6-astra"
     GPT_5_6 = "openai/gpt-5.6"
     GPT_5_6_SOL = "openai/gpt-5.6-sol"
     GPT_5_6_TERRA = "openai/gpt-5.6-terra"
@@ -93,6 +94,7 @@ class OpenRouterModel(str, Enum):
     DEEPSEEK_R1 = "openrouter/deepseek/deepseek-r1"
     GEMINI_2_5_PRO = "openrouter/google/gemini-2.5-pro"
     GEMINI_2_5_FLASH = "openrouter/google/gemini-2.5-flash"
+    GPT_6_ASTRA = "openrouter/openai/gpt-6-astra"
     GPT_5_6_SOL = "openrouter/openai/gpt-5.6-sol"
     GPT_5_6_TERRA = "openrouter/openai/gpt-5.6-terra"
     GPT_5_6_LUNA = "openrouter/openai/gpt-5.6-luna"
@@ -112,6 +114,7 @@ class VercelModel(str, Enum):
     CLAUDE_SONNET_4_6 = "vercel/anthropic/claude-sonnet-4.6"
     CLAUDE_OPUS_4_6 = "vercel/anthropic/claude-opus-4.6"
     CLAUDE_HAIKU_4_5 = "vercel/anthropic/claude-haiku-4.5"
+    GPT_6_ASTRA = "vercel/openai/gpt-6-astra"
     GPT_5_6_SOL = "vercel/openai/gpt-5.6-sol"
     GPT_5_6_TERRA = "vercel/openai/gpt-5.6-terra"
     GPT_5_6_LUNA = "vercel/openai/gpt-5.6-luna"
@@ -144,6 +147,7 @@ class OpenCodeModel(str, Enum):
     CLAUDE_SONNET_5 = "opencode/claude-sonnet-5"
     CLAUDE_HAIKU_4_5 = "opencode/claude-haiku-4-5"
     # OpenAI-backed OpenCode models
+    GPT_6_ASTRA = "opencode/gpt-6-astra"
     GPT_5_5 = "opencode/gpt-5.5"
     GPT_5_4 = "opencode/gpt-5.4"
     GPT_5_4_PRO = "opencode/gpt-5.4-pro"

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -385,6 +385,7 @@ The preferred field in agent config is `harness`, and it is required. Deprecated
 
 | Enum                    | Value                         |
 | ----------------------- | ----------------------------- |
+| `ClaudeCode.Fable_5_1`  | `anthropic/claude-fable-5-1`  |
 | `ClaudeCode.Fable_5`    | `anthropic/claude-fable-5`    |
 | `ClaudeCode.Opus_5`     | `anthropic/claude-opus-5`     |
 | `ClaudeCode.Opus_4_8`   | `anthropic/claude-opus-4-8`   |
@@ -417,6 +418,7 @@ The preferred field in agent config is `harness`, and it is required. Deprecated
 
 | Enum                               | Value                                   |
 | ---------------------------------- | --------------------------------------- |
+| `OpenRouterModel.Claude_Fable_5_1` | `openrouter/anthropic/claude-fable-5.1` |
 | `OpenRouterModel.Claude_Fable_5`   | `openrouter/anthropic/claude-fable-5`   |
 | `OpenRouterModel.Claude_Opus_5`    | `openrouter/anthropic/claude-opus-5`    |
 | `OpenRouterModel.Claude_Sonnet_5`  | `openrouter/anthropic/claude-sonnet-5`  |

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -402,7 +402,7 @@ The preferred field in agent config is `harness`, and it is required. Deprecated
 
 | Enum                              | Value                          |
 | --------------------------------- | ------------------------------ |
-| `OpenAICodex.GPT_6_Astra` | `openai/gpt-6-astra`          |
+| `OpenAICodex.GPT_6_Astra`         | `openai/gpt-6-astra`           |
 | `OpenAICodex.GPT_5_6`             | `openai/gpt-5.6` (alias → Sol) |
 | `OpenAICodex.GPT_5_6_Sol`         | `openai/gpt-5.6-sol`           |
 | `OpenAICodex.GPT_5_6_Terra`       | `openai/gpt-5.6-terra`         |

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -402,6 +402,7 @@ The preferred field in agent config is `harness`, and it is required. Deprecated
 
 | Enum                              | Value                          |
 | --------------------------------- | ------------------------------ |
+| `OpenAICodex.GPT_6_Astra` | `openai/gpt-6-astra`          |
 | `OpenAICodex.GPT_5_6`             | `openai/gpt-5.6` (alias → Sol) |
 | `OpenAICodex.GPT_5_6_Sol`         | `openai/gpt-5.6-sol`           |
 | `OpenAICodex.GPT_5_6_Terra`       | `openai/gpt-5.6-terra`         |

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -44,6 +44,7 @@ export enum Agent {
  * Claude Code model identifiers
  */
 export enum ClaudeCode {
+  Fable_5_1 = "anthropic/claude-fable-5-1",
   Fable_5 = "anthropic/claude-fable-5",
   Opus_4_5 = "anthropic/claude-opus-4-5",
   Opus_4_6 = "anthropic/claude-opus-4-6",
@@ -79,6 +80,7 @@ export enum OpenAICodex {
  * OpenRouter model identifiers — shared across agents that support OpenRouter
  */
 export enum OpenRouterModel {
+  Claude_Fable_5_1 = "openrouter/anthropic/claude-fable-5.1",
   Claude_Fable_5 = "openrouter/anthropic/claude-fable-5",
   Claude_Opus_5 = "openrouter/anthropic/claude-opus-5",
   Claude_Sonnet_5 = "openrouter/anthropic/claude-sonnet-5",
@@ -100,6 +102,7 @@ export enum OpenRouterModel {
  * Vercel AI Gateway model identifiers — shared across agents that support Vercel AI Gateway
  */
 export enum VercelModel {
+  Claude_Fable_5_1 = "vercel/anthropic/claude-fable-5.1",
   Claude_Fable_5 = "vercel/anthropic/claude-fable-5",
   Claude_Opus_5 = "vercel/anthropic/claude-opus-5",
   Claude_Sonnet_5 = "vercel/anthropic/claude-sonnet-5",
@@ -127,6 +130,7 @@ export enum VercelModel {
  */
 export enum OpenCodeModel {
   // Anthropic-backed OpenCode models
+  Claude_Fable_5_1 = "opencode/claude-fable-5-1",
   Claude_Fable_5 = "opencode/claude-fable-5",
   Claude_Opus_5 = "opencode/claude-opus-5",
   Claude_Opus_4_5 = "opencode/claude-opus-4-5",
@@ -157,6 +161,7 @@ export enum OpenCodeModel {
   Zen_Big_Pickle = "opencode/big-pickle",
   // Paid models
   Zen_MiniMax_M2_7 = "opencode/minimax-m2.7",
+  Zen_Claude_Fable_5_1 = "opencode/claude-fable-5-1",
   Zen_Claude_Fable_5 = "opencode/claude-fable-5",
   Zen_Claude_Opus_5 = "opencode/claude-opus-5",
   Zen_Claude_Sonnet_4_6 = "opencode/claude-sonnet-4-6",

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -62,6 +62,7 @@ export enum ClaudeCode {
  * OpenAI Codex model identifiers
  */
 export enum OpenAICodex {
+  GPT_6_Astra = "openai/gpt-6-astra",
   GPT_5_6 = "openai/gpt-5.6",
   GPT_5_6_Sol = "openai/gpt-5.6-sol",
   GPT_5_6_Terra = "openai/gpt-5.6-terra",
@@ -90,6 +91,7 @@ export enum OpenRouterModel {
   DeepSeek_R1 = "openrouter/deepseek/deepseek-r1",
   Gemini_2_5_Pro = "openrouter/google/gemini-2.5-pro",
   Gemini_2_5_Flash = "openrouter/google/gemini-2.5-flash",
+  GPT_6_Astra = "openrouter/openai/gpt-6-astra",
   GPT_5_6_Sol = "openrouter/openai/gpt-5.6-sol",
   GPT_5_6_Terra = "openrouter/openai/gpt-5.6-terra",
   GPT_5_6_Luna = "openrouter/openai/gpt-5.6-luna",
@@ -110,6 +112,7 @@ export enum VercelModel {
   Claude_Sonnet_4_6 = "vercel/anthropic/claude-sonnet-4.6",
   Claude_Opus_4_6 = "vercel/anthropic/claude-opus-4.6",
   Claude_Haiku_4_5 = "vercel/anthropic/claude-haiku-4.5",
+  GPT_6_Astra = "vercel/openai/gpt-6-astra",
   GPT_5_6_Sol = "vercel/openai/gpt-5.6-sol",
   GPT_5_6_Terra = "vercel/openai/gpt-5.6-terra",
   GPT_5_6_Luna = "vercel/openai/gpt-5.6-luna",
@@ -143,6 +146,7 @@ export enum OpenCodeModel {
   Claude_Sonnet_5 = "opencode/claude-sonnet-5",
   Claude_Haiku_4_5 = "opencode/claude-haiku-4-5",
   // OpenAI-backed OpenCode models
+  GPT_6_Astra = "opencode/gpt-6-astra",
   GPT_5_5 = "opencode/gpt-5.5",
   GPT_5_4 = "opencode/gpt-5.4",
   GPT_5_4_Pro = "opencode/gpt-5.4-pro",


### PR DESCRIPTION
## What

Adds Claude Fable 5.1 and GPT-6 Astra to the SDKs and the model picker, and corrects two picker entries that no longer match what the backend charges.

Changeset included: patch bump on `@upstash/box` and `@upstash/box-cli`.

## Claude Fable 5.1

Available on the Claude API, OpenRouter, Vercel AI Gateway and OpenCode Zen. Verified against each catalog rather than assumed.

```
ClaudeCode.Fable_5_1                anthropic/claude-fable-5-1
OpenRouterModel.Claude_Fable_5_1    openrouter/anthropic/claude-fable-5.1
VercelModel.Claude_Fable_5_1        vercel/anthropic/claude-fable-5.1
OpenCodeModel.Claude_Fable_5_1      opencode/claude-fable-5-1
OpenCodeModel.Zen_Claude_Fable_5_1  opencode/claude-fable-5-1
```

Note the spelling split: the Claude API and Zen use `claude-fable-5-1`, while the OpenRouter and Vercel gateways list it as `claude-fable-5.1`. Confirmed against OpenRouter's live `/api/v1/models` and the Vercel gateway catalog.

Eight picker entries, mirroring exactly where Fable 5 already appears. `CursorModel` is deliberately untouched, for both models: Cursor publishes no catalog I could check, so an entry there would be a guess.

Same members added to the Python SDK, plus the model table in the SDK README.

## GPT-6 Astra

Added to every catalog that carries it, each one checked rather than assumed. Unlike Fable 5.1 there is no spelling split: every provider uses `gpt-6-astra`.

```
OpenAICodex.GPT_6_Astra      openai/gpt-6-astra              OpenAI model page
OpenRouterModel.GPT_6_Astra  openrouter/openai/gpt-6-astra   OpenRouter live catalog
VercelModel.GPT_6_Astra      vercel/openai/gpt-6-astra       Vercel gateway catalog
OpenCodeModel.GPT_6_Astra    opencode/gpt-6-astra            Zen pricing page
```

Six picker entries, mirroring where the current OpenAI flagship already appears. Same members in the Python SDK, plus the SDK README table.

Not added: `gpt-6-astra-pro`, which OpenRouter lists at a price identical to plain astra while appearing on no OpenAI page and not on Zen; and `gpt-6-astra-fast`, which is a 2x billing mode rather than a model id on the OpenAI API, exposed as one only by the Vercel gateway.

## Picker corrections

`OpenAICodex.GPT_5_3_Codex_Spark` removed from the picker. It is a ChatGPT research preview, not an API model: its docs page 404s and the coordinator no longer prices it, so selecting it produced a run against a model that does not exist and would bill at the unknown-model default.

`OpenCodeModel.GPT_5_3_Codex_Spark` is deliberately kept. Same name, different product: Zen sells it and publishes a price.

GPT-5 Nano moved from the free group to the paid group and lost its `(Free)` suffix. Zen now charges $0.05 / $0.40 per MTok, so the picker was advertising free while the backend billed paid. Big Pickle is still genuinely free and stays.

## Not a breaking change

Both spark enum members remain exported from the TypeScript and Python SDKs. Removing them would break consumers, so they should be deprecated with JSDoc in a separate PR. Taking the option out of the picker is what stops users selecting it.

## Verification

- `pnpm ci:lint` passes across all four workspace projects
- `tsc --noEmit` clean on `packages/sdk` and `packages/cli`
- `packages/sdk` unit tests: 30 files, 431 passed
- `packages/cli` unit tests: 43 files, 479 passed
- Python `types.py` parses, with every added member carrying the intended value

Note for local checkouts: `packages/cli` resolves `@upstash/box` through a workspace symlink to `packages/sdk/dist`, so the CLI will not typecheck against a stale SDK build. Run `pnpm build` first. CI does this already.

## Related

This is the picker and SDK half of DX-2986. Pricing for both models is in upstash/box-backend#246 and the console display mirror is a separate PR on `DX-2986` in `upstash-console-v2`. The backend PR should land first; this one removes the `(Free)` label that the backend change would otherwise contradict.

