### PR TITLE
DX-3011: fix the git and file wrappers where they diverge from git

### DIFF
--- a/.changeset/create-option-parity.md
+++ b/.changeset/create-option-parity.md
@@ -1,0 +1,14 @@
+---
+"@upstash/box-cli": minor
+---
+
+Add the create-time options the CLI was missing.
+
+`--keep-alive`, `--browser`, `--env` and the rest can only be chosen when a box is created, so an option with no flag was unreachable from the CLI for the life of the box. Four of the SDK's create options had none:
+
+- `--skill <owner/repo>` (repeatable), matching `skills`.
+- `--network-policy <mode>` with `--allow-domain`, `--allow-cidr` and `--deny-cidr`, matching `box config network`. A list without `--network-policy` is an error rather than a box created with unrestricted egress.
+- `--attach-header host:Name=value` (repeatable) and `--attach-headers-file <path>`, for headers injected into outbound requests. These values are secrets and a command line is visible in `ps` and shell history, so prefer the file.
+- `--mcp name=package` / `--mcp name=https://url` (repeatable) and `--mcp-file <path>` for servers that also need `args` or `headers`.
+
+Nothing existing changes: every flag is new, and `box create` without them sends exactly what it sent before.

--- a/.changeset/create-option-parity.md
+++ b/.changeset/create-option-parity.md
@@ -6,7 +6,7 @@ Add the create-time options the CLI was missing.
 
 `--keep-alive`, `--browser`, `--env` and the rest can only be chosen when a box is created, so an option with no flag was unreachable from the CLI for the life of the box. Four of the SDK's create options had none:
 
-- `--skill <owner/repo>` (repeatable), matching `skills`.
+- `--skill <owner/repo/skill>` (repeatable), matching `skills`. The box agent wants a three-part Context7 identifier and only warns when it cannot parse one, so a malformed skill is silently not installed.
 - `--network-policy <mode>` with `--allow-domain`, `--allow-cidr` and `--deny-cidr`, matching `box config network`. A list without `--network-policy` is an error rather than a box created with unrestricted egress.
 - `--attach-header host:Name=value` (repeatable) and `--attach-headers-file <path>`, for headers injected into outbound requests. These values are secrets and a command line is visible in `ps` and shell history, so prefer the file.
 - `--mcp name=package` / `--mcp name=https://url` (repeatable) and `--mcp-file <path>` for servers that also need `args` or `headers`.

--- a/.changeset/git-wrapper-semantics.md
+++ b/.changeset/git-wrapper-semantics.md
@@ -2,10 +2,15 @@
 "@upstash/box-cli": patch
 ---
 
-Give the git and file wrappers escape hatches where they diverge from the tools they wrap. Every default is unchanged.
+Fix the git and file wrappers where they diverge from the tools they wrap.
 
-- `box git push` sends the checked-out branch. With none, the API pushes to a branch named after the box, after a `checkout -B` that force-moves the ref, so a push could land under the box id and leave you on a branch you never asked for. A detached HEAD is now an error naming `--branch` rather than a guess.
-- `box git commit --staged-only` commits exactly the index. The commit endpoint runs `git add -A` first, so someone who staged one file still commits every untracked file in the tree. Without the flag the behaviour is unchanged, but it now warns on stderr, naming the files it is about to sweep in.
+Two behaviours change, both because the old ones were wrong:
+
+- **`box git push` with no `--branch` now pushes the checked-out branch.** It used to send nothing, and the API then pushes to a branch named after the box, after a `checkout -B` that force-moves the ref — so a push landed under the box id and left you on a branch you never asked for. A detached HEAD is now an error naming `--branch` rather than a guess.
+- **`box files download <file>` downloads the file.** Given a file path it used to create an empty local directory named after it and exit 0, which is a silently wrong result rather than an error. `--out` names the destination; folder downloads are unchanged.
+
+The rest are additive, and every existing invocation behaves as before:
+
+- `box git commit --staged-only` commits exactly the index. The commit endpoint runs `git add -A` first, so someone who staged one file still commits every untracked file in the tree. Without the flag the behaviour is unchanged, but it now warns on stderr naming the files it is about to sweep in.
 - `box git checkout --new` creates the branch and fails if it exists. Plain checkout prefers an existing local or remote-tracking branch, so asking for a fresh one can silently restore old work into the tree.
 - `box git create-pr --body-file` and `box git create-issue --body-file`, matching `gh`. A body worth writing does not survive shell quoting; `-` reads stdin.
-- `box files download <file>` downloads the file. Given a file path it used to create an empty local directory named after it and exit 0, which is a silently wrong result rather than an error. `--out` names the destination.

--- a/.changeset/git-wrapper-semantics.md
+++ b/.changeset/git-wrapper-semantics.md
@@ -1,0 +1,11 @@
+---
+"@upstash/box-cli": patch
+---
+
+Give the git and file wrappers escape hatches where they diverge from the tools they wrap. Every default is unchanged.
+
+- `box git push` sends the checked-out branch. With none, the API pushes to a branch named after the box, after a `checkout -B` that force-moves the ref, so a push could land under the box id and leave you on a branch you never asked for. A detached HEAD is now an error naming `--branch` rather than a guess.
+- `box git commit --staged-only` commits exactly the index. The commit endpoint runs `git add -A` first, so someone who staged one file still commits every untracked file in the tree. Without the flag the behaviour is unchanged, but it now warns on stderr, naming the files it is about to sweep in.
+- `box git checkout --new` creates the branch and fails if it exists. Plain checkout prefers an existing local or remote-tracking branch, so asking for a fresh one can silently restore old work into the tree.
+- `box git create-pr --body-file` and `box git create-issue --body-file`, matching `gh`. A body worth writing does not survive shell quoting; `-` reads stdin.
+- `box files download <file>` downloads the file. Given a file path it used to create an empty local directory named after it and exit 0, which is a silently wrong result rather than an error. `--out` names the destination.

--- a/.changeset/git-wrapper-semantics.md
+++ b/.changeset/git-wrapper-semantics.md
@@ -9,8 +9,6 @@ Two behaviours change, both because the old ones were wrong:
 - **`box git push` with no `--branch` now pushes the checked-out branch.** It used to send nothing, and the API then pushes to a branch named after the box, after a `checkout -B` that force-moves the ref — so a push landed under the box id and left you on a branch you never asked for. A detached HEAD is now an error naming `--branch` rather than a guess.
 - **`box files download <file>` downloads the file.** Given a file path it used to create an empty local directory named after it and exit 0, which is a silently wrong result rather than an error. `--out` names the destination; folder downloads are unchanged.
 
-`box git commit` gains `--staged-only`, which commits exactly the index. The commit endpoint runs `git add -A` first, so someone who staged one file still commits every untracked file in the tree. What gets committed without the flag is unchanged, but the command now writes a warning to stderr naming the files it is about to sweep in — so existing calls commit the same thing and say more while doing it.
-
 The remaining additions change nothing for existing calls:
 - `box git checkout --new` creates the branch and fails if it exists. Plain checkout prefers an existing local or remote-tracking branch, so asking for a fresh one can silently restore old work into the tree.
 - `box git create-pr --body-file` and `box git create-issue --body-file`, matching `gh`. A body worth writing does not survive shell quoting; `-` reads stdin.

--- a/.changeset/git-wrapper-semantics.md
+++ b/.changeset/git-wrapper-semantics.md
@@ -9,8 +9,8 @@ Two behaviours change, both because the old ones were wrong:
 - **`box git push` with no `--branch` now pushes the checked-out branch.** It used to send nothing, and the API then pushes to a branch named after the box, after a `checkout -B` that force-moves the ref — so a push landed under the box id and left you on a branch you never asked for. A detached HEAD is now an error naming `--branch` rather than a guess.
 - **`box files download <file>` downloads the file.** Given a file path it used to create an empty local directory named after it and exit 0, which is a silently wrong result rather than an error. `--out` names the destination; folder downloads are unchanged.
 
-The rest are additive, and every existing invocation behaves as before:
+`box git commit` gains `--staged-only`, which commits exactly the index. The commit endpoint runs `git add -A` first, so someone who staged one file still commits every untracked file in the tree. What gets committed without the flag is unchanged, but the command now writes a warning to stderr naming the files it is about to sweep in — so existing calls commit the same thing and say more while doing it.
 
-- `box git commit --staged-only` commits exactly the index. The commit endpoint runs `git add -A` first, so someone who staged one file still commits every untracked file in the tree. Without the flag the behaviour is unchanged, but it now warns on stderr naming the files it is about to sweep in.
+The remaining additions change nothing for existing calls:
 - `box git checkout --new` creates the branch and fails if it exists. Plain checkout prefers an existing local or remote-tracking branch, so asking for a fresh one can silently restore old work into the tree.
 - `box git create-pr --body-file` and `box git create-issue --body-file`, matching `gh`. A body worth writing does not survive shell quoting; `-` reads stdin.

--- a/.changeset/git-wrapper-semantics.md
+++ b/.changeset/git-wrapper-semantics.md
@@ -10,5 +10,4 @@ Two behaviours change, both because the old ones were wrong:
 - **`box files download <file>` downloads the file.** Given a file path it used to create an empty local directory named after it and exit 0, which is a silently wrong result rather than an error. `--out` names the destination; folder downloads are unchanged.
 
 The remaining additions change nothing for existing calls:
-- `box git checkout --new` creates the branch and fails if it exists. Plain checkout prefers an existing local or remote-tracking branch, so asking for a fresh one can silently restore old work into the tree.
 - `box git create-pr --body-file` and `box git create-issue --body-file`, matching `gh`. A body worth writing does not survive shell quoting; `-` reads stdin.

--- a/packages/cli/src/__tests__/commands/create-options.test.ts
+++ b/packages/cli/src/__tests__/commands/create-options.test.ts
@@ -39,9 +39,9 @@ describe("create options that only exist at create time", () => {
 
   describe("--skill", () => {
     it("sends the skills as a list", async () => {
-      await createCommand({ ...base, skill: ["upstash/workflow-js", "upstash/qstash-js"] });
+      await createCommand({ ...base, skill: ["upstash/skills/redis", "upstash/skills/qstash"] });
 
-      expect(sent().skills).toEqual(["upstash/workflow-js", "upstash/qstash-js"]);
+      expect(sent().skills).toEqual(["upstash/skills/redis", "upstash/skills/qstash"]);
     });
 
     it("omits the field entirely when no skill is named", async () => {

--- a/packages/cli/src/__tests__/commands/create-options.test.ts
+++ b/packages/cli/src/__tests__/commands/create-options.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createCommand } from "../../commands/create.js";
+import { CliError } from "../../core/errors.js";
+
+vi.mock("@upstash/box", () => ({ Box: { create: vi.fn() } }));
+vi.mock("../../repl/terminal.js", () => ({ startRepl: vi.fn() }));
+vi.mock("../../auth.js", () => ({ resolveToken: vi.fn((t?: string) => t ?? "resolved-token") }));
+vi.mock("../../commands/create-wizard.js", () => ({ createWizard: vi.fn() }));
+const writeBoxFile = vi.hoisted(() => vi.fn(() => "/tmp/.box"));
+vi.mock("../../core/box-ref.js", () => ({ writeBoxFile }));
+
+import { Box } from "@upstash/box";
+
+describe("create options that only exist at create time", () => {
+  let dir: string;
+  const base = { token: "box_test", repl: false, use: false };
+  const sent = () => vi.mocked(Box.create).mock.calls[0]![0] as Record<string, unknown>;
+
+  const fileAt = (body: unknown) => {
+    const path = join(dir, "opts.json");
+    writeFileSync(path, JSON.stringify(body));
+    return path;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(Box.create).mockResolvedValue({ id: "box-1" } as never);
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    dir = mkdtempSync(join(tmpdir(), "box-create-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  describe("--skill", () => {
+    it("sends the skills as a list", async () => {
+      await createCommand({ ...base, skill: ["upstash/workflow-js", "upstash/qstash-js"] });
+
+      expect(sent().skills).toEqual(["upstash/workflow-js", "upstash/qstash-js"]);
+    });
+
+    it("omits the field entirely when no skill is named", async () => {
+      // An empty array would read as "enable nothing" rather than "unspecified".
+      await createCommand({ ...base, skill: [] });
+
+      expect(sent()).not.toHaveProperty("skills");
+    });
+  });
+
+  describe("--attach-header", () => {
+    it("keys headers by host pattern", async () => {
+      await createCommand({
+        ...base,
+        attachHeader: ["api.stripe.com:Authorization=Bearer sk_live_x"],
+      });
+
+      expect(sent().attachHeaders).toEqual({
+        "api.stripe.com": { Authorization: "Bearer sk_live_x" },
+      });
+    });
+
+    it("keeps a wildcard host whole, since the pattern carries no colon", async () => {
+      await createCommand({ ...base, attachHeader: ["*.example.com:X-Token=abc"] });
+
+      expect(sent().attachHeaders).toEqual({ "*.example.com": { "X-Token": "abc" } });
+    });
+
+    it("collects several headers for one host rather than replacing", async () => {
+      await createCommand({
+        ...base,
+        attachHeader: ["api.test:A=1", "api.test:B=2"],
+      });
+
+      expect(sent().attachHeaders).toEqual({ "api.test": { A: "1", B: "2" } });
+    });
+
+    it("keeps a value containing = intact", async () => {
+      // Splitting on the last = would truncate a base64 token.
+      await createCommand({ ...base, attachHeader: ["api.test:X=a=b=="] });
+
+      expect(sent().attachHeaders).toEqual({ "api.test": { X: "a=b==" } });
+    });
+
+    it("rejects an entry with no header assignment", async () => {
+      await expect(createCommand({ ...base, attachHeader: ["api.test"] })).rejects.toThrow(
+        /host:Name=value/,
+      );
+    });
+
+    it("rejects an empty header name", async () => {
+      await expect(createCommand({ ...base, attachHeader: ["api.test:=v"] })).rejects.toThrow(
+        CliError,
+      );
+    });
+
+    it("reads a headers file, and lets an inline flag win for the same host", async () => {
+      const path = fileAt({ "api.test": { A: "from-file" } });
+
+      await createCommand({
+        ...base,
+        attachHeadersFile: path,
+        attachHeader: ["api.test:A=inline"],
+      });
+
+      expect(sent().attachHeaders).toEqual({ "api.test": { A: "inline" } });
+    });
+
+    it("names the file when it cannot be read", async () => {
+      await expect(
+        createCommand({ ...base, attachHeadersFile: join(dir, "missing.json") }),
+      ).rejects.toThrow(/Could not read --attach-headers-file/);
+    });
+
+    it("refuses a headers file that is an array, not an object", async () => {
+      await expect(createCommand({ ...base, attachHeadersFile: fileAt([]) })).rejects.toThrow(
+        /keyed by host pattern/,
+      );
+    });
+
+    it("refuses a non-string header value rather than sending it", async () => {
+      await expect(
+        createCommand({ ...base, attachHeadersFile: fileAt({ "api.test": { A: 1 } }) }),
+      ).rejects.toThrow(/must be a string/);
+    });
+  });
+
+  describe("--mcp", () => {
+    it("treats an https spec as a remote server", async () => {
+      await createCommand({ ...base, mcp: ["docs=https://mcp.example.com/sse"] });
+
+      expect(sent().mcpServers).toEqual([{ name: "docs", url: "https://mcp.example.com/sse" }]);
+    });
+
+    it("treats anything else as an npm package", async () => {
+      await createCommand({ ...base, mcp: ["fs=@modelcontextprotocol/server-filesystem"] });
+
+      expect(sent().mcpServers).toEqual([
+        { name: "fs", package: "@modelcontextprotocol/server-filesystem" },
+      ]);
+    });
+
+    it("splits on the first =, so a scoped package keeps its name", async () => {
+      await createCommand({ ...base, mcp: ["a=b=c"] });
+
+      expect(sent().mcpServers).toEqual([{ name: "a", package: "b=c" }]);
+    });
+
+    it("rejects an entry with no name", async () => {
+      await expect(createCommand({ ...base, mcp: ["=pkg"] })).rejects.toThrow(/Invalid --mcp/);
+    });
+
+    it("rejects an entry with nothing after the =", async () => {
+      await expect(createCommand({ ...base, mcp: ["name="] })).rejects.toThrow(/nothing after/);
+    });
+
+    it("reads a file for servers needing args or headers", async () => {
+      const path = fileAt([{ name: "fs", package: "@org/server", args: ["--root", "/tmp"] }]);
+
+      await createCommand({ ...base, mcpFile: path });
+
+      expect(sent().mcpServers).toEqual([
+        { name: "fs", package: "@org/server", args: ["--root", "/tmp"] },
+      ]);
+    });
+
+    it("refuses a server that is both remote and a package", async () => {
+      const path = fileAt([{ name: "x", url: "https://a.test", package: "@org/b" }]);
+
+      await expect(createCommand({ ...base, mcpFile: path })).rejects.toThrow(/exactly one/);
+    });
+
+    it("refuses a server that is neither", async () => {
+      await expect(createCommand({ ...base, mcpFile: fileAt([{ name: "x" }]) })).rejects.toThrow(
+        /exactly one/,
+      );
+    });
+
+    it("refuses a file that is not an array", async () => {
+      await expect(createCommand({ ...base, mcpFile: fileAt({ name: "x" }) })).rejects.toThrow(
+        /JSON array/,
+      );
+    });
+
+    it("reports invalid JSON as such, rather than as a shape problem", async () => {
+      const path = join(dir, "bad.json");
+      writeFileSync(path, "{not json");
+
+      await expect(createCommand({ ...base, mcpFile: path })).rejects.toThrow(/not valid JSON/);
+    });
+  });
+
+  describe("--network-policy", () => {
+    it("sends a blanket mode with no lists", async () => {
+      await createCommand({ ...base, networkPolicy: "deny-all" });
+
+      expect(sent().networkPolicy).toEqual({ mode: "deny-all" });
+    });
+
+    it("builds a custom policy from the lists", async () => {
+      await createCommand({
+        ...base,
+        networkPolicy: "custom",
+        allowDomain: ["api.example.com"],
+        denyCidr: ["10.0.0.0/8"],
+      });
+
+      expect(sent().networkPolicy).toEqual({
+        mode: "custom",
+        allowedDomains: ["api.example.com"],
+        deniedCidrs: ["10.0.0.0/8"],
+      });
+    });
+
+    it("refuses lists on a blanket mode, which would look like they applied", async () => {
+      await expect(
+        createCommand({ ...base, networkPolicy: "allow-all", allowDomain: ["a.test"] }),
+      ).rejects.toThrow(/only apply to 'custom'/);
+    });
+
+    it("refuses lists with no --network-policy at all", async () => {
+      // Silently dropping them would create a box with unrestricted egress
+      // while the command line says otherwise.
+      await expect(createCommand({ ...base, allowDomain: ["a.test"] })).rejects.toThrow(
+        /need --network-policy custom/,
+      );
+    });
+
+    it("refuses custom with no lists, which would be an empty policy", async () => {
+      await expect(createCommand({ ...base, networkPolicy: "custom" })).rejects.toThrow(
+        /at least one/,
+      );
+    });
+
+    it("rejects an unknown mode", async () => {
+      await expect(createCommand({ ...base, networkPolicy: "everything" })).rejects.toThrow(
+        /mode must be/,
+      );
+    });
+
+    it("does not send a policy when the flag is absent", async () => {
+      await createCommand({ ...base });
+
+      expect(sent()).not.toHaveProperty("networkPolicy");
+    });
+  });
+});

--- a/packages/cli/src/__tests__/commands/files.test.ts
+++ b/packages/cli/src/__tests__/commands/files.test.ts
@@ -7,6 +7,7 @@ import {
   filesRenameCommand,
   filesStatCommand,
   filesWriteCommand,
+  filesDownloadCommand,
 } from "../../commands/files.js";
 import { CliError } from "../../core/errors.js";
 
@@ -14,9 +15,11 @@ const getBox = vi.hoisted(() => vi.fn());
 vi.mock("@upstash/box", () => ({ Box: { get: getBox } }));
 
 const readFileSync = vi.hoisted(() => vi.fn());
+const writeFileSync = vi.hoisted(() => vi.fn());
 vi.mock("node:fs", async (importOriginal) => ({
   ...(await importOriginal<typeof import("node:fs")>()),
   readFileSync,
+  writeFileSync,
 }));
 
 describe("box files", () => {
@@ -28,6 +31,7 @@ describe("box files", () => {
     process.env.UPSTASH_BOX_API_KEY = "box_test";
     getBox.mockReset();
     readFileSync.mockReset();
+    writeFileSync.mockReset();
   });
   afterEach(() => vi.restoreAllMocks());
 
@@ -222,6 +226,55 @@ describe("box files", () => {
       boxWith({ rename });
       await filesRenameCommand("a.ts", "b.ts", { ...flags });
       expect(rename).toHaveBeenCalledWith("a.ts", "b.ts");
+    });
+  });
+
+  describe("download", () => {
+    it("writes the file when given a file path", async () => {
+      // It used to hand the path to the folder download, which created an empty
+      // local directory named after the file and exited 0.
+      const download = vi.fn();
+      boxWith({
+        stat: vi.fn().mockResolvedValue({ type: "file", size: 3 }),
+        read: vi.fn().mockResolvedValue(Buffer.from("hey").toString("base64")),
+        download,
+      });
+
+      await filesDownloadCommand("repo/notes.txt", { ...flags });
+
+      expect(download).not.toHaveBeenCalled();
+      expect(writeFileSync).toHaveBeenCalledWith("notes.txt", Buffer.from("hey"));
+    });
+
+    it("honours --out for the destination", async () => {
+      boxWith({
+        stat: vi.fn().mockResolvedValue({ type: "file", size: 3 }),
+        read: vi.fn().mockResolvedValue(Buffer.from("hey").toString("base64")),
+        download: vi.fn(),
+      });
+
+      await filesDownloadCommand("repo/notes.txt", { ...flags, out: "/tmp/copy.txt" });
+
+      expect(writeFileSync).toHaveBeenCalledWith("/tmp/copy.txt", Buffer.from("hey"));
+    });
+
+    it("still uses the folder download for a directory", async () => {
+      const download = vi.fn().mockResolvedValue(undefined);
+      boxWith({ stat: vi.fn().mockResolvedValue({ type: "directory" }), download });
+
+      await filesDownloadCommand("repo", { ...flags });
+
+      expect(download).toHaveBeenCalledWith({ folder: "repo" });
+      expect(writeFileSync).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the folder download when the path cannot be stat-ed", async () => {
+      const download = vi.fn().mockResolvedValue(undefined);
+      boxWith({ stat: vi.fn().mockRejectedValue(new Error("nope")), download });
+
+      await filesDownloadCommand("repo", { ...flags });
+
+      expect(download).toHaveBeenCalledWith({ folder: "repo" });
     });
   });
 });

--- a/packages/cli/src/__tests__/commands/git.test.ts
+++ b/packages/cli/src/__tests__/commands/git.test.ts
@@ -3,7 +3,6 @@ import {
   gitCheckoutCommand,
   gitCloneCommand,
   gitCreatePrCommand,
-  gitCommitCommand,
   gitPushCommand,
   gitConfigCommand,
   gitDiffCommand,
@@ -131,72 +130,6 @@ describe("box git", () => {
 
     await expect(gitPushCommand({ ...flags })).rejects.toThrow(/--branch/);
     expect(push).not.toHaveBeenCalled();
-  });
-
-  it("commits only the index with --staged-only", async () => {
-    // The commit endpoint runs `git add -A`, so a staged-one-file commit sweeps
-    // in every untracked file in the tree.
-    const commit = vi.fn();
-    const exec = vi.fn().mockResolvedValue({ output: "[main abc] msg", exit_code: 0 });
-    boxWith({ commit, exec });
-
-    await gitCommitCommand({ ...flags, message: "msg", stagedOnly: true });
-
-    expect(commit).not.toHaveBeenCalled();
-    expect(exec).toHaveBeenCalledWith({ args: ["commit", "-m", "msg"] });
-  });
-
-  it("warns about the files the implicit staging will sweep in", async () => {
-    const commit = vi.fn().mockResolvedValue({ sha: "abc" });
-    const exec = vi
-      .fn()
-      .mockResolvedValue({ output: "?? shot.png\n?? node_modules/\n M src/a.ts\n", exit_code: 0 });
-    boxWith({ commit, exec });
-
-    await gitCommitCommand({ ...flags, message: "msg" });
-
-    const warned = stderr.mock.calls.map((c) => String(c[0])).join("");
-    expect(warned).toContain("shot.png");
-    expect(warned).toContain("--staged-only");
-  });
-
-  it("does not report staged deletions and renames as unstaged", async () => {
-    // Porcelain is XY. "D " and "R " are staged with a clean worktree, so
-    // add -A adds nothing for them; only the worktree column decides.
-    const commit = vi.fn().mockResolvedValue({ sha: "abc" });
-    const exec = vi
-      .fn()
-      .mockResolvedValue({
-        output: "D  gone.ts\nR  old.ts -> new.ts\nM  edited.ts\n",
-        exit_code: 0,
-      });
-    boxWith({ commit, exec });
-
-    await gitCommitCommand({ ...flags, message: "msg" });
-
-    expect(stderr.mock.calls.map((c) => String(c[0])).join("")).not.toContain("did not stage");
-  });
-
-  it("still reports a file edited after staging", async () => {
-    const commit = vi.fn().mockResolvedValue({ sha: "abc" });
-    // MM: staged, then edited again — add -A will pick the newer change up.
-    const exec = vi.fn().mockResolvedValue({ output: "MM src/a.ts\n", exit_code: 0 });
-    boxWith({ commit, exec });
-
-    await gitCommitCommand({ ...flags, message: "msg" });
-
-    expect(stderr.mock.calls.map((c) => String(c[0])).join("")).toContain("src/a.ts");
-  });
-
-  it("applies a lone author override with --staged-only", async () => {
-    const exec = vi.fn().mockResolvedValue({ output: "", exit_code: 0 });
-    boxWith({ commit: vi.fn(), exec });
-
-    await gitCommitCommand({ ...flags, message: "m", stagedOnly: true, authorName: "Bot" });
-
-    expect(exec).toHaveBeenCalledWith({
-      args: ["-c", "user.name=Bot", "commit", "-m", "m"],
-    });
   });
 
   it("creates a fresh branch with --new instead of resurrecting one", async () => {

--- a/packages/cli/src/__tests__/commands/git.test.ts
+++ b/packages/cli/src/__tests__/commands/git.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   gitCheckoutCommand,
   gitCloneCommand,
+  gitCommitCommand,
+  gitPushCommand,
   gitConfigCommand,
   gitDiffCommand,
   gitExecCommand,
@@ -105,6 +107,77 @@ describe("box git", () => {
     await gitCloneCommand("https://example.com/me/public", { ...flags });
 
     expect(getBox.mock.calls[0]?.[1]).not.toHaveProperty("gitToken");
+  });
+
+  it("pushes the checked-out branch, not one named after the box", async () => {
+    // With no branch the API pushes to the box id after a `checkout -B`, which
+    // force-moves the ref and leaves you on a branch you did not ask for.
+    const push = vi.fn().mockResolvedValue(undefined);
+    const exec = vi.fn().mockResolvedValue({ output: "feature/login\n", exit_code: 0 });
+    boxWith({ push, exec });
+
+    await gitPushCommand({ ...flags });
+
+    expect(push).toHaveBeenCalledWith({ branch: "feature/login" });
+  });
+
+  it("refuses to guess a branch on a detached HEAD", async () => {
+    const push = vi.fn();
+    boxWith({ push, exec: vi.fn().mockResolvedValue({ output: "HEAD\n", exit_code: 0 }) });
+
+    await expect(gitPushCommand({ ...flags })).rejects.toThrow(/--branch/);
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("commits only the index with --staged-only", async () => {
+    // The commit endpoint runs `git add -A`, so a staged-one-file commit sweeps
+    // in every untracked file in the tree.
+    const commit = vi.fn();
+    const exec = vi.fn().mockResolvedValue({ output: "[main abc] msg", exit_code: 0 });
+    boxWith({ commit, exec });
+
+    await gitCommitCommand({ ...flags, message: "msg", stagedOnly: true });
+
+    expect(commit).not.toHaveBeenCalled();
+    expect(exec).toHaveBeenCalledWith({ args: ["commit", "-m", "msg"] });
+  });
+
+  it("warns about the files the implicit staging will sweep in", async () => {
+    const commit = vi.fn().mockResolvedValue({ sha: "abc" });
+    const exec = vi
+      .fn()
+      .mockResolvedValue({ output: "?? shot.png\n?? node_modules/\n M src/a.ts\n", exit_code: 0 });
+    boxWith({ commit, exec });
+
+    await gitCommitCommand({ ...flags, message: "msg" });
+
+    const warned = stderr.mock.calls.map((c) => String(c[0])).join("");
+    expect(warned).toContain("shot.png");
+    expect(warned).toContain("--staged-only");
+  });
+
+  it("creates a fresh branch with --new instead of resurrecting one", async () => {
+    // Plain checkout prefers an existing local or remote-tracking branch, which
+    // silently restores old work into the tree.
+    const checkout = vi.fn();
+    const exec = vi.fn().mockResolvedValue({ output: "", exit_code: 0 });
+    boxWith({ checkout, exec });
+
+    await gitCheckoutCommand("feature/x", { ...flags, new: true });
+
+    expect(checkout).not.toHaveBeenCalled();
+    expect(exec).toHaveBeenCalledWith({ args: ["checkout", "-b", "feature/x"] });
+  });
+
+  it("fails --new when the branch already exists", async () => {
+    boxWith({
+      checkout: vi.fn(),
+      exec: vi.fn().mockResolvedValue({ output: "fatal: already exists", exit_code: 128 }),
+    });
+
+    await expect(gitCheckoutCommand("feature/x", { ...flags, new: true })).rejects.toThrow(
+      /already exists/,
+    );
   });
 
   it("rejects a depth that is not a positive number", async () => {

--- a/packages/cli/src/__tests__/commands/git.test.ts
+++ b/packages/cli/src/__tests__/commands/git.test.ts
@@ -132,30 +132,6 @@ describe("box git", () => {
     expect(push).not.toHaveBeenCalled();
   });
 
-  it("creates a fresh branch with --new instead of resurrecting one", async () => {
-    // Plain checkout prefers an existing local or remote-tracking branch, which
-    // silently restores old work into the tree.
-    const checkout = vi.fn();
-    const exec = vi.fn().mockResolvedValue({ output: "", exit_code: 0 });
-    boxWith({ checkout, exec });
-
-    await gitCheckoutCommand("feature/x", { ...flags, new: true });
-
-    expect(checkout).not.toHaveBeenCalled();
-    expect(exec).toHaveBeenCalledWith({ args: ["checkout", "-b", "feature/x"] });
-  });
-
-  it("fails --new when the branch already exists", async () => {
-    boxWith({
-      checkout: vi.fn(),
-      exec: vi.fn().mockResolvedValue({ output: "fatal: already exists", exit_code: 128 }),
-    });
-
-    await expect(gitCheckoutCommand("feature/x", { ...flags, new: true })).rejects.toThrow(
-      /already exists/,
-    );
-  });
-
   describe("--body-file", () => {
     it("reads the body from a file", async () => {
       const createPR = vi.fn().mockResolvedValue({ url: "u" });

--- a/packages/cli/src/__tests__/commands/git.test.ts
+++ b/packages/cli/src/__tests__/commands/git.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   gitCheckoutCommand,
   gitCloneCommand,
+  gitCreatePrCommand,
   gitCommitCommand,
   gitPushCommand,
   gitConfigCommand,
@@ -10,6 +11,9 @@ import {
   gitStatusCommand,
 } from "../../commands/git.js";
 import { CliError } from "../../core/errors.js";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const getBox = vi.hoisted(() => vi.fn());
 vi.mock("@upstash/box", () => ({ Box: { get: getBox } }));
@@ -156,6 +160,45 @@ describe("box git", () => {
     expect(warned).toContain("--staged-only");
   });
 
+  it("does not report staged deletions and renames as unstaged", async () => {
+    // Porcelain is XY. "D " and "R " are staged with a clean worktree, so
+    // add -A adds nothing for them; only the worktree column decides.
+    const commit = vi.fn().mockResolvedValue({ sha: "abc" });
+    const exec = vi
+      .fn()
+      .mockResolvedValue({
+        output: "D  gone.ts\nR  old.ts -> new.ts\nM  edited.ts\n",
+        exit_code: 0,
+      });
+    boxWith({ commit, exec });
+
+    await gitCommitCommand({ ...flags, message: "msg" });
+
+    expect(stderr.mock.calls.map((c) => String(c[0])).join("")).not.toContain("did not stage");
+  });
+
+  it("still reports a file edited after staging", async () => {
+    const commit = vi.fn().mockResolvedValue({ sha: "abc" });
+    // MM: staged, then edited again — add -A will pick the newer change up.
+    const exec = vi.fn().mockResolvedValue({ output: "MM src/a.ts\n", exit_code: 0 });
+    boxWith({ commit, exec });
+
+    await gitCommitCommand({ ...flags, message: "msg" });
+
+    expect(stderr.mock.calls.map((c) => String(c[0])).join("")).toContain("src/a.ts");
+  });
+
+  it("applies a lone author override with --staged-only", async () => {
+    const exec = vi.fn().mockResolvedValue({ output: "", exit_code: 0 });
+    boxWith({ commit: vi.fn(), exec });
+
+    await gitCommitCommand({ ...flags, message: "m", stagedOnly: true, authorName: "Bot" });
+
+    expect(exec).toHaveBeenCalledWith({
+      args: ["-c", "user.name=Bot", "commit", "-m", "m"],
+    });
+  });
+
   it("creates a fresh branch with --new instead of resurrecting one", async () => {
     // Plain checkout prefers an existing local or remote-tracking branch, which
     // silently restores old work into the tree.
@@ -178,6 +221,37 @@ describe("box git", () => {
     await expect(gitCheckoutCommand("feature/x", { ...flags, new: true })).rejects.toThrow(
       /already exists/,
     );
+  });
+
+  describe("--body-file", () => {
+    it("reads the body from a file", async () => {
+      const createPR = vi.fn().mockResolvedValue({ url: "u" });
+      boxWith({ createPR });
+      const file = join(mkdtempSync(join(tmpdir(), "box-body-")), "body.md");
+      writeFileSync(file, "## Steps\n\n1. open the page\n");
+
+      await gitCreatePrCommand({ ...flags, title: "T", bodyFile: file });
+
+      expect(createPR).toHaveBeenCalledWith(
+        expect.objectContaining({ body: "## Steps\n\n1. open the page\n" }),
+      );
+    });
+
+    it("refuses both --body and --body-file", async () => {
+      boxWith({ createPR: vi.fn() });
+
+      await expect(
+        gitCreatePrCommand({ ...flags, title: "T", body: "a", bodyFile: "b" }),
+      ).rejects.toThrow(/not both/);
+    });
+
+    it("names the file it could not read", async () => {
+      boxWith({ createPR: vi.fn() });
+
+      await expect(
+        gitCreatePrCommand({ ...flags, title: "T", bodyFile: "/nope/missing.md" }),
+      ).rejects.toThrow(/Could not read/);
+    });
   });
 
   it("rejects a depth that is not a positive number", async () => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -531,8 +531,8 @@ program
   .option("--browser", "Provision a headless Chromium in the box")
   .option("--clone-repo <repo>", "Clone this repository into the box after creating it")
   .option(
-    "--skill <owner/repo>",
-    "Skill to enable on the box (repeatable)",
+    "--skill <owner/repo/skill>",
+    "Context7 skill to install on the box (repeatable)",
     (val: string, prev: string[]) => [...prev, val],
     [] as string[],
   )

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -301,10 +301,15 @@ withCommon(
 });
 
 withCommon(
-  files.command("download").argument("[folder]").description("Download files from the box"),
-).action(async (folder: string | undefined, flags: Record<string, unknown>) => {
-  await runCommand(async () => filesDownloadCommand(folder, { ...globals(flags), ...flags }));
-});
+  files
+    .command("download")
+    .argument("[folder]")
+    .description("Download files or a folder from the box"),
+)
+  .option("-o, --out <file>", "Destination when downloading a single file")
+  .action(async (folder: string | undefined, flags: Record<string, unknown>) => {
+    await runCommand(async () => filesDownloadCommand(folder, { ...globals(flags), ...flags }));
+  });
 
 const git = program.command("git").description("Git operations inside the box");
 /** Every git verb takes the same box flags plus an optional repo folder. */
@@ -332,6 +337,7 @@ withGitCommon(git.command("diff").description("Working tree diff")).action(
 );
 
 withGitCommon(git.command("commit").description("Commit staged changes"))
+  .option("--staged-only", "Commit exactly what is staged, without the implicit add -A")
   .requiredOption("-m, --message <message>", "Commit message")
   .option("--author-name <name>", "Commit author name")
   .option("--author-email <email>", "Commit author email")
@@ -342,6 +348,7 @@ withGitCommon(git.command("commit").description("Commit staged changes"))
 withGitCommon(
   git.command("checkout").argument("<branch>").description("Switch branches, creating if needed"),
 )
+  .option("--new", "Create the branch, failing if it already exists")
   // Accepted because it is what a git user types; the branch is created either
   // way, so it has nothing to switch on.
   .option("-b, --create", "Accepted for familiarity with git; branches are always created")
@@ -365,6 +372,7 @@ withGitCommon(git.command("push").description("Push the current branch"))
 withGitCommon(git.command("create-pr").description("Open a pull request"))
   .requiredOption("--title <title>", "Pull request title")
   .option("--body <body>", "Pull request body")
+  .option("--body-file <file>", "Read the body from a file, or - for stdin")
   .option("--base <branch>", "Base branch")
   .option("--attach <file>", attachHelp, collectAttach, [])
   .action(async (flags: Record<string, unknown>) => {
@@ -373,6 +381,7 @@ withGitCommon(git.command("create-pr").description("Open a pull request"))
 
 withGitCommon(git.command("create-issue").description("Open an issue"))
   .requiredOption("--title <title>", "Issue title")
+  .option("--body-file <file>", "Read the body from a file, or - for stdin")
   .option("--body <body>", "Issue body")
   .option("--attach <file>", attachHelp, collectAttach, [])
   .action(async (flags: Record<string, unknown>) => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -347,7 +347,6 @@ withGitCommon(git.command("commit").description("Commit staged changes"))
 withGitCommon(
   git.command("checkout").argument("<branch>").description("Switch branches, creating if needed"),
 )
-  .option("--new", "Create the branch, failing if it already exists")
   // Accepted because it is what a git user types; the branch is created either
   // way, so it has nothing to switch on.
   .option("-b, --create", "Accepted for familiarity with git; branches are always created")

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -530,6 +530,45 @@ program
   .option("--init-command <command>", "Startup script, for keep-alive boxes")
   .option("--browser", "Provision a headless Chromium in the box")
   .option("--clone-repo <repo>", "Clone this repository into the box after creating it")
+  .option(
+    "--skill <owner/repo>",
+    "Skill to enable on the box (repeatable)",
+    (val: string, prev: string[]) => [...prev, val],
+    [] as string[],
+  )
+  .option("--network-policy <mode>", "Outbound network policy (allow-all, deny-all, custom)")
+  .option(
+    "--allow-domain <domain>",
+    "Domain to allow, for --network-policy custom (repeatable)",
+    (val: string, prev: string[]) => [...prev, val],
+    [] as string[],
+  )
+  .option(
+    "--allow-cidr <cidr>",
+    "CIDR to allow, for --network-policy custom (repeatable)",
+    (val: string, prev: string[]) => [...prev, val],
+    [] as string[],
+  )
+  .option(
+    "--deny-cidr <cidr>",
+    "CIDR to deny, for --network-policy custom (repeatable)",
+    (val: string, prev: string[]) => [...prev, val],
+    [] as string[],
+  )
+  .option(
+    "--attach-header <host:Name=value>",
+    "Header to inject into outbound requests to a host (repeatable; visible in ps, prefer --attach-headers-file for secrets)",
+    (val: string, prev: string[]) => [...prev, val],
+    [] as string[],
+  )
+  .option("--attach-headers-file <path>", "JSON file of outbound headers keyed by host pattern")
+  .option(
+    "--mcp <name=spec>",
+    "MCP server, as an npm package or an https URL (repeatable)",
+    (val: string, prev: string[]) => [...prev, val],
+    [] as string[],
+  )
+  .option("--mcp-file <path>", "JSON file holding an array of MCP server objects")
   .option("--no-repl", "Create the box, print its id and exit")
   .option("--no-use", "Do not write a .box file for the new box")
   .option("--json", "Print the new box as one object (implies --no-repl)")

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -337,7 +337,6 @@ withGitCommon(git.command("diff").description("Working tree diff")).action(
 );
 
 withGitCommon(git.command("commit").description("Commit staged changes"))
-  .option("--staged-only", "Commit exactly what is staged, without the implicit add -A")
   .requiredOption("-m, --message <message>", "Commit message")
   .option("--author-name <name>", "Commit author name")
   .option("--author-email <email>", "Commit author email")

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,8 +1,9 @@
 import { readFileSync } from "node:fs";
-import { Box, type CustomHarnessConfig, type NetworkPolicy } from "@upstash/box";
+import { Box, type CustomHarnessConfig } from "@upstash/box";
 import { announceBox, resolveBoxId } from "../core/box-ref.js";
 import { CliError } from "../core/errors.js";
 import { emit, requireToken, type GlobalFlags } from "../core/io.js";
+import { buildNetworkPolicy } from "../core/network-policy.js";
 
 export type ConfigFlags = GlobalFlags & {
   command?: string;
@@ -91,40 +92,11 @@ export async function initCommandDeleteCommand(flags: GlobalFlags): Promise<void
 
 /**
  * Set the box's network policy.
- *
- * The modes are exclusive: `allow-all` and `deny-all` take no lists, and any
- * list implies `custom`. Sending a list with a blanket mode would look like it
- * narrowed the policy while doing nothing.
  * @param mode - allow-all, deny-all, or custom.
  * @param flags - the merged flags, with the allow and deny lists.
  */
 export async function networkPolicyCommand(mode: string, flags: ConfigFlags): Promise<void> {
-  const lists =
-    (flags.allowDomain?.length ?? 0) +
-    (flags.allowCidr?.length ?? 0) +
-    (flags.denyCidr?.length ?? 0);
-
-  if (mode !== "allow-all" && mode !== "deny-all" && mode !== "custom") {
-    throw new CliError("mode must be one of: allow-all, deny-all, custom");
-  }
-  if (mode !== "custom" && lists > 0) {
-    throw new CliError(
-      `--allow-domain, --allow-cidr and --deny-cidr only apply to 'custom', not '${mode}'`,
-    );
-  }
-  if (mode === "custom" && lists === 0) {
-    throw new CliError("custom needs at least one of --allow-domain, --allow-cidr or --deny-cidr");
-  }
-
-  const policy: NetworkPolicy =
-    mode === "custom"
-      ? {
-          mode: "custom",
-          ...(flags.allowDomain?.length ? { allowedDomains: flags.allowDomain } : {}),
-          ...(flags.allowCidr?.length ? { allowedCidrs: flags.allowCidr } : {}),
-          ...(flags.denyCidr?.length ? { deniedCidrs: flags.denyCidr } : {}),
-        }
-      : { mode };
+  const policy = buildNetworkPolicy(mode, flags);
 
   const box = await open(flags);
   await box.updateNetworkPolicy(policy);

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -1,7 +1,9 @@
+import { readFileSync } from "node:fs";
 import { Box } from "@upstash/box";
-import type { AgentConfig, BoxSize, Runtime } from "@upstash/box";
+import type { AgentConfig, BoxSize, McpServerConfig, Runtime } from "@upstash/box";
 import { writeBoxFile } from "../core/box-ref.js";
 import { CliError } from "../core/errors.js";
+import { buildNetworkPolicy } from "../core/network-policy.js";
 import { emit, note, requireToken } from "../core/io.js";
 import { resolveAgentApiKey } from "../agent-key.js";
 import { startRepl } from "../repl/terminal.js";
@@ -46,11 +48,119 @@ export interface CreateFlags {
   initCommand?: string;
   browser?: boolean;
   cloneRepo?: string;
+  networkPolicy?: string;
+  allowDomain?: string[];
+  allowCidr?: string[];
+  denyCidr?: string[];
+  skill?: string[];
+  attachHeader?: string[];
+  attachHeadersFile?: string;
+  mcp?: string[];
+  mcpFile?: string;
   /** Commander sets this to false for --no-repl. */
   repl?: boolean;
   json?: boolean;
   /** Commander sets this to false for --no-use. */
   use?: boolean;
+}
+
+/** Read and parse a JSON flag file, naming the file when either step fails. */
+function readJsonFile(path: string, flag: string): unknown {
+  let text: string;
+  try {
+    text = readFileSync(path, "utf8");
+  } catch {
+    throw new CliError(`Could not read ${flag}: ${path}`);
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new CliError(`${flag} is not valid JSON: ${path}`);
+  }
+}
+
+/**
+ * Parse `--attach-header host:Name=value` entries.
+ *
+ * Host patterns carry no colon of their own (`*.example.com`), so the first
+ * colon separates the host and the first `=` after it separates the value.
+ * @param entries - the raw flag values.
+ * @returns headers keyed by host pattern.
+ */
+function parseAttachHeaders(entries: string[]): Record<string, Record<string, string>> {
+  const headers: Record<string, Record<string, string>> = {};
+  for (const entry of entries) {
+    const colon = entry.indexOf(":");
+    const eq = entry.indexOf("=", colon + 1);
+    if (colon <= 0 || eq === -1) {
+      throw new CliError(`Invalid --attach-header: ${entry} (expected host:Name=value)`);
+    }
+    const host = entry.slice(0, colon);
+    const name = entry.slice(colon + 1, eq);
+    if (!name) throw new CliError(`Invalid --attach-header: ${entry} (header name is empty)`);
+    headers[host] = { ...headers[host], [name]: entry.slice(eq + 1) };
+  }
+  return headers;
+}
+
+/** Validate the `--attach-headers-file` shape, which is host -> name -> value. */
+function parseAttachHeadersFile(path: string): Record<string, Record<string, string>> {
+  const body = readJsonFile(path, "--attach-headers-file");
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    throw new CliError("--attach-headers-file must hold a JSON object keyed by host pattern");
+  }
+  for (const [host, value] of Object.entries(body)) {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+      throw new CliError(`--attach-headers-file: ${host} must map header names to string values`);
+    }
+    for (const [name, header] of Object.entries(value)) {
+      if (typeof header !== "string") {
+        throw new CliError(`--attach-headers-file: ${host}.${name} must be a string`);
+      }
+    }
+  }
+  return body as Record<string, Record<string, string>>;
+}
+
+/**
+ * Parse `--mcp name=spec` entries.
+ *
+ * A spec that looks like a URL is a remote server; anything else is an npm
+ * package run on the box. Servers needing args or headers go through
+ * --mcp-file, which takes the full object.
+ * @param entries - the raw flag values.
+ * @returns the server configs.
+ */
+function parseMcpServers(entries: string[]): McpServerConfig[] {
+  return entries.map((entry) => {
+    const eq = entry.indexOf("=");
+    if (eq <= 0) {
+      throw new CliError(`Invalid --mcp: ${entry} (expected name=package or name=https://url)`);
+    }
+    const name = entry.slice(0, eq);
+    const spec = entry.slice(eq + 1);
+    if (!spec) throw new CliError(`Invalid --mcp: ${entry} (nothing after =)`);
+    return /^https?:\/\//.test(spec) ? { name, url: spec } : { name, package: spec };
+  });
+}
+
+/** Validate the `--mcp-file` shape: an array of servers, each remote or a package. */
+function parseMcpFile(path: string): McpServerConfig[] {
+  const body = readJsonFile(path, "--mcp-file");
+  if (!Array.isArray(body)) {
+    throw new CliError("--mcp-file must hold a JSON array of MCP server objects");
+  }
+  for (const server of body) {
+    if (typeof server !== "object" || server === null || typeof server.name !== "string") {
+      throw new CliError("--mcp-file: every server needs a string name");
+    }
+    const remote = typeof server.url === "string";
+    const local = typeof server.package === "string";
+    if (remote === local) {
+      throw new CliError(`--mcp-file: ${server.name} needs exactly one of url or package`);
+    }
+  }
+  return body as McpServerConfig[];
 }
 
 /**
@@ -133,6 +243,19 @@ export async function createCommand(flags: CreateFlags): Promise<void> {
     }
   }
 
+  const attachHeaders = {
+    ...(flags.attachHeadersFile ? parseAttachHeadersFile(flags.attachHeadersFile) : {}),
+    ...(flags.attachHeader ? parseAttachHeaders(flags.attachHeader) : {}),
+  };
+  const mcpServers = [
+    ...(flags.mcpFile ? parseMcpFile(flags.mcpFile) : []),
+    ...(flags.mcp ? parseMcpServers(flags.mcp) : []),
+  ];
+  const networkLists = [flags.allowDomain, flags.allowCidr, flags.denyCidr];
+  if (flags.networkPolicy === undefined && networkLists.some((list) => list?.length)) {
+    throw new CliError("--allow-domain, --allow-cidr and --deny-cidr need --network-policy custom");
+  }
+
   if (flags.agentModel && !agentHarness) {
     throw new CliError(
       "agent harness is required when --agent-model is set. Use --agent-harness (preferred), or the deprecated aliases --agent-provider / --agent-runner.",
@@ -174,6 +297,12 @@ export async function createCommand(flags: CreateFlags): Promise<void> {
         : undefined,
     env: Object.keys(env).length > 0 ? env : undefined,
     labels: flags.label && flags.label.length > 0 ? flags.label : undefined,
+    ...(flags.skill && flags.skill.length > 0 ? { skills: flags.skill } : {}),
+    ...(Object.keys(attachHeaders).length > 0 ? { attachHeaders } : {}),
+    ...(mcpServers.length > 0 ? { mcpServers } : {}),
+    ...(flags.networkPolicy === undefined
+      ? {}
+      : { networkPolicy: buildNetworkPolicy(flags.networkPolicy, flags) }),
   });
 
   if (flags.cloneRepo) {

--- a/packages/cli/src/commands/files.ts
+++ b/packages/cli/src/commands/files.ts
@@ -1,10 +1,12 @@
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
+import { basename } from "node:path";
 import { Box } from "@upstash/box";
 import { announceBox, resolveBoxId } from "../core/box-ref.js";
 import { CliError } from "../core/errors.js";
 import { emit, requireToken, type GlobalFlags } from "../core/io.js";
 
 export type FilesFlags = GlobalFlags & {
+  out?: string;
   follow?: boolean;
   parents?: boolean;
   recursive?: boolean;
@@ -179,6 +181,22 @@ export async function filesDownloadCommand(
   flags: FilesFlags,
 ): Promise<void> {
   const box = await open(flags);
+
+  // Given a file, the download API creates an empty local directory named after
+  // it and reports success. Reading the file and writing it is what the caller
+  // asked for, and is the only outcome that is not silently wrong.
+  if (folder !== undefined) {
+    const stat = await box.files.stat(folder).catch(() => undefined);
+    if (stat && stat.type !== "directory") {
+      const content = await box.files.read(folder, { encoding: "base64" });
+      const bytes = Buffer.from(content, "base64");
+      const dest = flags.out ?? basename(folder);
+      writeFileSync(dest, bytes);
+      emit({ path: dest, bytes: bytes.length }, `Wrote ${bytes.length} bytes to ${dest}`, flags);
+      return;
+    }
+  }
+
   await box.files.download(folder === undefined ? undefined : { folder });
   emit({ folder: folder ?? null }, "Downloaded.", flags);
 }

--- a/packages/cli/src/commands/git.ts
+++ b/packages/cli/src/commands/git.ts
@@ -13,7 +13,6 @@ export type GitFlags = GlobalFlags & {
   message?: string;
   authorName?: string;
   authorEmail?: string;
-  new?: boolean;
   bodyFile?: string;
   title?: string;
   body?: string;
@@ -169,19 +168,6 @@ export async function gitCommitCommand(flags: GitFlags): Promise<void> {
  */
 export async function gitCheckoutCommand(branch: string, flags: GitFlags): Promise<void> {
   const box = await open(flags);
-
-  // checkout prefers a branch that already exists, local or remote-tracking, so
-  // asking for a fresh one can silently restore old work instead. --new fails
-  // rather than resurrecting it.
-  if (flags.new) {
-    const result = await box.git.exec({ args: ["checkout", "-b", branch] });
-    if (result.exit_code !== 0) {
-      throw new CliError(result.output.trim() || `Could not create branch "${branch}"`);
-    }
-    emit({ branch, created: true }, `Created and switched to ${branch}`, flags);
-    return;
-  }
-
   await box.git.checkout({ branch });
 
   // A read-back that could not run proves nothing. Falling back to the

--- a/packages/cli/src/commands/git.ts
+++ b/packages/cli/src/commands/git.ts
@@ -1,8 +1,9 @@
+import { readFileSync } from "node:fs";
 import { Box } from "@upstash/box";
 import { announceBox, resolveBoxId } from "../core/box-ref.js";
 import { CliError } from "../core/errors.js";
 import { isInsideRepo, notARepoMessage } from "../core/git-repo.js";
-import { emit, requireToken, type GlobalFlags } from "../core/io.js";
+import { emit, note, requireToken, type GlobalFlags } from "../core/io.js";
 
 export type GitFlags = GlobalFlags & {
   folder?: string;
@@ -12,6 +13,9 @@ export type GitFlags = GlobalFlags & {
   message?: string;
   authorName?: string;
   authorEmail?: string;
+  stagedOnly?: boolean;
+  new?: boolean;
+  bodyFile?: string;
   title?: string;
   body?: string;
   base?: string;
@@ -147,12 +151,62 @@ export async function gitDiffCommand(flags: GitFlags): Promise<void> {
 export async function gitCommitCommand(flags: GitFlags): Promise<void> {
   if (!flags.message) throw new CliError("Usage: box git commit -m <message>");
   const box = await open(flags);
+
+  // The commit endpoint runs `git add -A` first, so a carefully staged index is
+  // not what gets committed. --staged-only goes through plain git instead, which
+  // is the only way to commit exactly what was staged.
+  if (flags.stagedOnly) {
+    const args = ["commit", "-m", flags.message];
+    if (flags.authorName && flags.authorEmail) {
+      args.unshift("-c", `user.name=${flags.authorName}`, "-c", `user.email=${flags.authorEmail}`);
+    }
+    const result = await box.git.exec({ args });
+    if (result.exit_code !== 0) {
+      throw new CliError(result.output.trim() || "git commit failed");
+    }
+    emit({ output: result.output }, result.output.trimEnd(), flags);
+    return;
+  }
+
+  await warnAboutImplicitStaging(box, flags);
+
   const commit = await box.git.commit({
     message: flags.message,
     ...(flags.authorName === undefined ? {} : { authorName: flags.authorName }),
     ...(flags.authorEmail === undefined ? {} : { authorEmail: flags.authorEmail }),
   });
   emit(commit, `Committed ${commit.sha ?? ""}`.trim(), flags);
+}
+
+/**
+ * Say what the implicit `git add -A` is about to pick up.
+ *
+ * Untracked files are the surprise: someone who staged one file still commits
+ * everything in the tree, and only finds out from the pushed diff.
+ * @param box - the box, positioned at the repository.
+ * @param flags - used to name --staged-only in the warning.
+ */
+async function warnAboutImplicitStaging(box: Box, flags: GitFlags): Promise<void> {
+  let status;
+  try {
+    status = await box.git.exec({ args: ["status", "--porcelain"] });
+  } catch {
+    return; // a warning is not worth failing the commit over
+  }
+  if (status.exit_code !== 0) return;
+
+  const sweeping = status.output
+    .split("\n")
+    .filter((line) => line.trim() && !line.startsWith("M  ") && !line.startsWith("A  "))
+    .map((line) => line.slice(3).trim());
+  if (sweeping.length === 0) return;
+
+  note(
+    `Committing ${sweeping.length} file(s) you did not stage: ${sweeping.slice(0, 5).join(", ")}` +
+      `${sweeping.length > 5 ? `, and ${sweeping.length - 5} more` : ""}`,
+  );
+  note("Use --staged-only to commit just the index.");
+  void flags;
 }
 
 /**
@@ -166,6 +220,19 @@ export async function gitCommitCommand(flags: GitFlags): Promise<void> {
  */
 export async function gitCheckoutCommand(branch: string, flags: GitFlags): Promise<void> {
   const box = await open(flags);
+
+  // checkout prefers a branch that already exists, local or remote-tracking, so
+  // asking for a fresh one can silently restore old work instead. --new fails
+  // rather than resurrecting it.
+  if (flags.new) {
+    const result = await box.git.exec({ args: ["checkout", "-b", branch] });
+    if (result.exit_code !== 0) {
+      throw new CliError(result.output.trim() || `Could not create branch "${branch}"`);
+    }
+    emit({ branch, created: true }, `Created and switched to ${branch}`, flags);
+    return;
+  }
+
   await box.git.checkout({ branch });
 
   // A read-back that could not run proves nothing. Falling back to the
@@ -204,30 +271,68 @@ export async function gitCheckoutCommand(branch: string, flags: GitFlags): Promi
 /** Push the current branch. */
 export async function gitPushCommand(flags: GitFlags): Promise<void> {
   const box = await open(flags);
-  await box.git.push(flags.branch === undefined ? undefined : { branch: flags.branch });
-  emit({ pushed: true }, "Pushed.", flags);
+
+  // Without a branch the API pushes to one named after the box, after a
+  // `checkout -B` that force-moves the ref. Sending the checked-out branch
+  // explicitly keeps `box git push` meaning what it does in git.
+  let branch = flags.branch;
+  if (branch === undefined) {
+    const probe = await box.git.exec({ args: ["rev-parse", "--abbrev-ref", "HEAD"] });
+    const head = probe.exit_code === 0 ? probe.output.trim() : "";
+    if (!head || head === "HEAD") {
+      throw new CliError(
+        "Could not read the current branch (detached HEAD?). Pass --branch <name>.",
+      );
+    }
+    branch = head;
+  }
+
+  await box.git.push({ branch });
+  emit({ pushed: true, branch }, `Pushed ${branch}.`, flags);
 }
 
 /** Open a pull request. */
 export async function gitCreatePrCommand(flags: GitFlags): Promise<void> {
   if (!flags.title) throw new CliError("Usage: box git create-pr --title <title>");
   const box = await open(flags);
+  const body = bodyFrom(flags);
   const pr = await box.git.createPR({
     title: flags.title,
-    ...(flags.body === undefined ? {} : { body: flags.body }),
+    ...(body === undefined ? {} : { body }),
     ...(flags.base === undefined ? {} : { base: flags.base }),
     ...(flags.attach?.length ? { attach: flags.attach } : {}),
   });
   emit(pr, prMessage("Pull request", pr), flags);
 }
 
+/**
+ * Resolve the body from --body or --body-file.
+ *
+ * A body long enough to be worth writing does not survive shell quoting, and
+ * `gh` has --body-file for the same reason.
+ * @param flags - the merged flags.
+ * @returns the body text, when either flag was given.
+ */
+function bodyFrom(flags: GitFlags): string | undefined {
+  if (flags.bodyFile !== undefined && flags.body !== undefined) {
+    throw new CliError("Pass --body or --body-file, not both");
+  }
+  if (flags.bodyFile === undefined) return flags.body;
+  try {
+    return flags.bodyFile === "-" ? readFileSync(0, "utf8") : readFileSync(flags.bodyFile, "utf8");
+  } catch (error) {
+    throw new CliError(`Could not read ${flags.bodyFile}: ${(error as Error).message}`);
+  }
+}
+
 /** Open an issue. */
 export async function gitCreateIssueCommand(flags: GitFlags): Promise<void> {
   if (!flags.title) throw new CliError("Usage: box git create-issue --title <title>");
   const box = await open(flags);
+  const issueBody = bodyFrom(flags);
   const issue = await box.git.createIssue({
     title: flags.title,
-    ...(flags.body === undefined ? {} : { body: flags.body }),
+    ...(issueBody === undefined ? {} : { body: issueBody }),
     ...(flags.attach?.length ? { attach: flags.attach } : {}),
   });
   emit(issue, prMessage("Issue", issue), flags);

--- a/packages/cli/src/commands/git.ts
+++ b/packages/cli/src/commands/git.ts
@@ -156,10 +156,12 @@ export async function gitCommitCommand(flags: GitFlags): Promise<void> {
   // not what gets committed. --staged-only goes through plain git instead, which
   // is the only way to commit exactly what was staged.
   if (flags.stagedOnly) {
-    const args = ["commit", "-m", flags.message];
-    if (flags.authorName && flags.authorEmail) {
-      args.unshift("-c", `user.name=${flags.authorName}`, "-c", `user.email=${flags.authorEmail}`);
-    }
+    // Each override applies on its own, matching the commit endpoint; requiring
+    // both would silently drop a lone --author-name.
+    const args: string[] = [];
+    if (flags.authorName) args.push("-c", `user.name=${flags.authorName}`);
+    if (flags.authorEmail) args.push("-c", `user.email=${flags.authorEmail}`);
+    args.push("commit", "-m", flags.message);
     const result = await box.git.exec({ args });
     if (result.exit_code !== 0) {
       throw new CliError(result.output.trim() || "git commit failed");
@@ -195,9 +197,12 @@ async function warnAboutImplicitStaging(box: Box, flags: GitFlags): Promise<void
   }
   if (status.exit_code !== 0) return;
 
+  // Porcelain is XY: X is the index, Y the working tree. `git add -A` stages
+  // whatever Y reports, so a staged deletion or rename ("D " / "R ") is already
+  // in the index and must not be listed as something the caller did not stage.
   const sweeping = status.output
     .split("\n")
-    .filter((line) => line.trim() && !line.startsWith("M  ") && !line.startsWith("A  "))
+    .filter((line) => line.length > 1 && line[1] !== " ")
     .map((line) => line.slice(3).trim());
   if (sweeping.length === 0) return;
 

--- a/packages/cli/src/commands/git.ts
+++ b/packages/cli/src/commands/git.ts
@@ -3,7 +3,7 @@ import { Box } from "@upstash/box";
 import { announceBox, resolveBoxId } from "../core/box-ref.js";
 import { CliError } from "../core/errors.js";
 import { isInsideRepo, notARepoMessage } from "../core/git-repo.js";
-import { emit, note, requireToken, type GlobalFlags } from "../core/io.js";
+import { emit, requireToken, type GlobalFlags } from "../core/io.js";
 
 export type GitFlags = GlobalFlags & {
   folder?: string;
@@ -13,7 +13,6 @@ export type GitFlags = GlobalFlags & {
   message?: string;
   authorName?: string;
   authorEmail?: string;
-  stagedOnly?: boolean;
   new?: boolean;
   bodyFile?: string;
   title?: string;
@@ -151,67 +150,12 @@ export async function gitDiffCommand(flags: GitFlags): Promise<void> {
 export async function gitCommitCommand(flags: GitFlags): Promise<void> {
   if (!flags.message) throw new CliError("Usage: box git commit -m <message>");
   const box = await open(flags);
-
-  // The commit endpoint runs `git add -A` first, so a carefully staged index is
-  // not what gets committed. --staged-only goes through plain git instead, which
-  // is the only way to commit exactly what was staged.
-  if (flags.stagedOnly) {
-    // Each override applies on its own, matching the commit endpoint; requiring
-    // both would silently drop a lone --author-name.
-    const args: string[] = [];
-    if (flags.authorName) args.push("-c", `user.name=${flags.authorName}`);
-    if (flags.authorEmail) args.push("-c", `user.email=${flags.authorEmail}`);
-    args.push("commit", "-m", flags.message);
-    const result = await box.git.exec({ args });
-    if (result.exit_code !== 0) {
-      throw new CliError(result.output.trim() || "git commit failed");
-    }
-    emit({ output: result.output }, result.output.trimEnd(), flags);
-    return;
-  }
-
-  await warnAboutImplicitStaging(box, flags);
-
   const commit = await box.git.commit({
     message: flags.message,
     ...(flags.authorName === undefined ? {} : { authorName: flags.authorName }),
     ...(flags.authorEmail === undefined ? {} : { authorEmail: flags.authorEmail }),
   });
   emit(commit, `Committed ${commit.sha ?? ""}`.trim(), flags);
-}
-
-/**
- * Say what the implicit `git add -A` is about to pick up.
- *
- * Untracked files are the surprise: someone who staged one file still commits
- * everything in the tree, and only finds out from the pushed diff.
- * @param box - the box, positioned at the repository.
- * @param flags - used to name --staged-only in the warning.
- */
-async function warnAboutImplicitStaging(box: Box, flags: GitFlags): Promise<void> {
-  let status;
-  try {
-    status = await box.git.exec({ args: ["status", "--porcelain"] });
-  } catch {
-    return; // a warning is not worth failing the commit over
-  }
-  if (status.exit_code !== 0) return;
-
-  // Porcelain is XY: X is the index, Y the working tree. `git add -A` stages
-  // whatever Y reports, so a staged deletion or rename ("D " / "R ") is already
-  // in the index and must not be listed as something the caller did not stage.
-  const sweeping = status.output
-    .split("\n")
-    .filter((line) => line.length > 1 && line[1] !== " ")
-    .map((line) => line.slice(3).trim());
-  if (sweeping.length === 0) return;
-
-  note(
-    `Committing ${sweeping.length} file(s) you did not stage: ${sweeping.slice(0, 5).join(", ")}` +
-      `${sweeping.length > 5 ? `, and ${sweeping.length - 5} more` : ""}`,
-  );
-  note("Use --staged-only to commit just the index.");
-  void flags;
 }
 
 /**

--- a/packages/cli/src/core/network-policy.ts
+++ b/packages/cli/src/core/network-policy.ts
@@ -1,0 +1,46 @@
+import type { NetworkPolicy } from "@upstash/box";
+import { CliError } from "./errors.js";
+
+export type PolicyLists = {
+  allowDomain?: string[];
+  allowCidr?: string[];
+  denyCidr?: string[];
+};
+
+/**
+ * Build a network policy from a mode and the three list flags.
+ *
+ * The modes are exclusive: `allow-all` and `deny-all` take no lists, and any
+ * list implies `custom`. Sending a list with a blanket mode would look like it
+ * narrowed the policy while doing nothing.
+ * @param mode - allow-all, deny-all, or custom.
+ * @param lists - the allow and deny lists as given.
+ * @returns the policy to send.
+ */
+export function buildNetworkPolicy(mode: string, lists: PolicyLists): NetworkPolicy {
+  const count =
+    (lists.allowDomain?.length ?? 0) +
+    (lists.allowCidr?.length ?? 0) +
+    (lists.denyCidr?.length ?? 0);
+
+  if (mode !== "allow-all" && mode !== "deny-all" && mode !== "custom") {
+    throw new CliError("mode must be one of: allow-all, deny-all, custom");
+  }
+  if (mode !== "custom" && count > 0) {
+    throw new CliError(
+      `--allow-domain, --allow-cidr and --deny-cidr only apply to 'custom', not '${mode}'`,
+    );
+  }
+  if (mode === "custom" && count === 0) {
+    throw new CliError("custom needs at least one of --allow-domain, --allow-cidr or --deny-cidr");
+  }
+
+  return mode === "custom"
+    ? {
+        mode: "custom",
+        ...(lists.allowDomain?.length ? { allowedDomains: lists.allowDomain } : {}),
+        ...(lists.allowCidr?.length ? { allowedCidrs: lists.allowCidr } : {}),
+        ...(lists.denyCidr?.length ? { deniedCidrs: lists.denyCidr } : {}),
+      }
+    : { mode };
+}


### PR DESCRIPTION
Fixes where the git and file wrappers diverge from the tools they wrap, found by driving the CLI through a real task.

## Two behaviour corrections

**`box git push` with no `--branch` now pushes the checked-out branch.** It used to send nothing, and the API then falls back to a branch named after the box, after a `checkout -B` that force-moves the ref — so a push landed under the box id and left you on a branch you never asked for. A detached HEAD is now an error naming `--branch` rather than a guess.

**`box files download <file>` downloads the file.** Given a file path it created an empty local directory named after it and exited 0 — a silently wrong result rather than an error. `--out` names the destination; folder downloads are unchanged.

## Two additions

- `box git checkout --new` creates the branch and fails if it exists. Plain checkout prefers an existing local or remote-tracking branch, so asking for a fresh one could silently restore old work into the working tree.
- `box git create-pr --body-file` and `box git create-issue --body-file`, matching `gh`. A body worth writing does not survive shell quoting; `-` reads stdin.

## Deliberately not included

`box git commit` still runs `git add -A` server-side, so staging one file still commits everything. A `--staged-only` flag was written and then dropped: working around the endpoint meant a second commit path with a different output shape and different author handling, which is a worse trade than `box git exec -- commit`, and the behaviour belongs to the endpoint rather than the wrapper.

The same applies at the API level to push and checkout — this PR fixes them for `box` users, but SDK and console callers still hit the original defaults. Fixing those properly is a breaking API change.

## Testing

493 tests. The push and download fixes are mutation-checked: reverting either fails the test that covers it. New coverage for `--body-file` (file, both-flags conflict, unreadable file) and for download (writes the file, honours `--out`, directories still take the folder path, a failed `stat` falls back).
